### PR TITLE
Fix header and footer font sizes in about/help pages

### DIFF
--- a/app/assets/stylesheets/dromedary.scss
+++ b/app/assets/stylesheets/dromedary.scss
@@ -194,8 +194,6 @@ body.blacklight-contacts-new,
 body.blacklight-contacts-create {
   background-color: #f2f2f2;
   color: #6e6e6e;    
-  font-family: 'Open Sans', sans-serif;
-  font-size: 16px;
   line-height: 1.6;
 
   > .container {

--- a/app/views/static/about_med.html.erb
+++ b/app/views/static/about_med.html.erb
@@ -98,18 +98,9 @@
       <DT>Christina Powell</DT>
       <DD><FONT size=-1>Coordinator, Encoded text services, DLPS</FONT></DD>
       <DT>Matt Stoeffler</DT>
-      <DD><FONT size=-1>Interface designer, DLPS
+      <DD><FONT size=-1>Interface designer, DLPS</FONT></DD>
 
       <P>Earlier stages of the project received invaluable contributions from Maria Bonn (interface design and documentation), Nigel Kerr (programming), James Moske (MED conversion and HyperBibliography editing), David Ruddy (HyperBibliography production and project design), and especially the head of DLPS, John Price Wilkin (Project Director, grant period), among others. *MEC is a product of the University of Michigan Digital Library Production Service.</DD></DL>
-      <HR>
-      <CENTER><A HREF="/h/hyperbib/">
-      HyperBibliography</A>
-      | <A HREF="/m/med/">MED</A>
-      | <A HREF="/c/cme/">Corpus</A>
-      | <A HREF="../resources.html">Other Resources</A>
-      | About | <A HREF="../help.html">Help</A>
-      | <A HREF="/m/mec/index.html">MEC Main Page</A></CENTER>
-
 
     </div>
   </div>


### PR DESCRIPTION
Missing end tag in about page caused footer text to shrink.
Removed extraneous static font size/styling affecting header on about/help pages.