### PR TITLE
adds oed but not doe entries in related definitions

### DIFF
--- a/app/views/catalog/_related_entries.html.erb
+++ b/app/views/catalog/_related_entries.html.erb
@@ -1,9 +1,14 @@
 <% doc_presenter = index_presenter(@document) %>
 <% ent = doc_presenter.entry %>
-<div class="panel panel-default show-related">
-   <div class="panel-heading">Related Dictionary Entries</div>
-   <div class="panel-body">
 
-   	<% fake_oed = "oed info" ; fake_oed_warning = "OED is not free" %>
-   	<a class="oed-link" href=""><%== ent.id %></a>&nbsp;<%== fake_oed %>&nbsp;Note: <%== fake_oed_warning %>&nbsp;</div>
-</div>
+<% if ! ent.oedlink.nil? %>
+	<div class="panel panel-default show-related">
+	  <div class="panel-heading">Related Dictionary Entries</div>
+	   <div class="panel-body">
+	   	<p class="oed-subscription-warning" style="font-size: 12px;">Please note that the OED is a subscription resource</p>
+
+	   	<% oed_href = "http://www.oed.com/view/Entry/#{ent.oedlink.oed_id}" %>
+	   	<a class="oed-link" href=<%= oed_href %> >(OED) <%== ent.oedlink.oed_head %></a>
+	  	</div>
+	</div>
+<% end %>

--- a/app/views/catalog/_show_header_default.html.erb
+++ b/app/views/catalog/_show_header_default.html.erb
@@ -1,0 +1,2 @@
+<% # bookmark/folder functions -%>
+<%#= render_document_heading(document, :tag => :h1) %>


### PR DESCRIPTION
adds oed but not doe entries in related definitions.

Also removes default h1 tag in entry (show) page document heading.

I'll create a new ticket for doe entries.