### PR TITLE
Change system to use one json file instead of a zillion

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,8 @@ end
 
 # When developing in tandem, a relative path is nice and easy
 
-# gem 'middle_english_dictionary', path: "/Users/dueberb/devel/med/middle_english_dictionary"
-gem 'middle_english_dictionary', '=1.0.2'
+gem 'middle_english_dictionary', path: "/Users/dueberb/devel/med/middle_english_dictionary"
+# gem 'middle_english_dictionary', '=1.0.2'
 
 
 # Rails and blacklight

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+PATH
+  remote: /Users/dueberb/devel/med/middle_english_dictionary
+  specs:
+    middle_english_dictionary (1.0.2)
+      multi_json
+      nokogiri (~> 1.6)
+      representable
+
 GEM
   remote: https://gems.www.lib.umich.edu/
   remote: https://rubygems.org/
@@ -148,10 +156,6 @@ GEM
     marc-fastxmlwriter (1.0.0)
       marc (~> 1.0)
     method_source (0.9.0)
-    middle_english_dictionary (1.0.2)
-      multi_json
-      nokogiri (~> 1.6)
-      representable
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -338,7 +342,7 @@ DEPENDENCIES
   jquery-rails
   listen
   mail_form (= 1.7.0)
-  middle_english_dictionary (= 1.0.2)
+  middle_english_dictionary!
   mysql2 (< 0.5.0)
   nestive (= 0.6.0)
   nokogiri

--- a/indexer/pry_session.rb
+++ b/indexer/pry_session.rb
@@ -13,20 +13,19 @@ require_relative '../lib/med_installer/indexer/entry_json_reader'
 unless ARGV.size > 0
   puts "pry_session.rb; get a pry session with a bunch of entries loaded up"
   puts
-  puts "Usage: ruby pry_session.rb /path/to/dir/with/json"
+  puts "Usage: ruby pry_session.rb /path/to/json/file"
   puts
   exit(1)
 end
 
 
 
-datadir = Pathname(ARGV.shift)
+datafile = Pathname(ARGV.shift)
 letters = ARGV.shift
 
 
 settings = {
-    'med.data_dir' => datadir,
-    'med.letters' =>  letters
+    'med.data_file' => datafile
 }
 
 entries = MedInstaller::EntryJsonReader.new(settings)

--- a/lib/med_installer/convert.rb
+++ b/lib/med_installer/convert.rb
@@ -1,6 +1,6 @@
 require 'middle_english_dictionary'
 require 'hanami/cli'
-require 'concurrent'
+require 'tempfile'
 
 module MedInstaller
   # Convert a bunch of Dromedary xml files into a more useful format.
@@ -10,88 +10,97 @@ module MedInstaller
     desc "Convert the xml files into (faster) json objects (takes a long time)"
 
     argument :datadir, required: true, desc: "The data directory. Converted files will be put in <datadir>/json"
-    argument :dirname, required: false, desc: "one letter to convert"
+    argument :letter, required: false, desc: "one letter to convert"
 
-
-    def new_pool
-      threads = Concurrent.processor_count > 1 ? Concurrent.processor_count - 1 : 1
-      Concurrent::ThreadPoolExecutor.new(
-        min_threads:     threads,
-        max_threads:     threads,
-        max_queue:       100,
-        fallback_policy: :caller_runs
-      )
-    end
 
     def find_oed_file(datapath)
       xmldir = datapath + 'xml'
       xmldir.children.select {|x| x.to_s =~ /MED2OED/}.first
     end
 
-    def call(datadir:, dirname: '*')
+
+    def call(datadir:, letter: nil)
       datapath = Pathname(datadir).realdirpath
       validate_xml_dir(datapath)
 
-      pool = new_pool
-      logger.info "Loading OED links so we can push them into entries"
-      oed    = MiddleEnglishDictionary::Collection::OEDLinkSet.from_xml_file(find_oed_file(datapath))
-      letter = ''
-      Dir.glob("#{datapath}/xml/#{dirname}/MED*xml").each_with_index do |filename, i|
-        logger.info "#{i} done" if i > 0 and i % 2500 == 0
+      tmpfile_name = Pathname(Dir.tmpdir) + 'entries.json.tmp'
+      targetfile = if letter.nil?
+                     datapath + 'entries.json'
+                   else
+                     datapath + "entries_#{letter}.json"
+                   end
+      outfile = File.open(tmpfile_name, 'w:utf-8')
+
+      logger.info "Targeting #{targetfile}"
+      oedfile = find_oed_file(datapath)
+      logger.info "Loading OED links from #{oedfile} so we can push them into entries"
+      oed    = MiddleEnglishDictionary::Collection::OEDLinkSet.from_xml_file(oedfile)
+      count = 0
+      Dir.glob("#{datapath}/xml/#{letter}*/MED*xml").each do |filename|
+        count += 1
+        logger.info "#{count} done" if count > 0 and count % 2500 == 0
         basename, this_letter = letter_and_filename(filename)
         if this_letter != letter
           start_new_letter(datapath, this_letter)
           letter = this_letter
         end
 
-        # pool.post do
-        dump_json(datapath, filename, basename, oed)
-        # end
+        entry = create_and_fill_entry(xmlfilepath: filename, oedlinks: oed)
+        outfile.puts entry.to_json
       end
+      logger.info "Finished converting #{count} entries."
 
-      pool.shutdown
-      pool.wait_for_termination
+      outfile.close
+
+      logger.info "Copying temporary file to real location in #{datapath}"
+
+      # Copy the tempfile over if we made it this far
+      FileUtils.cp(tmpfile_name, targetfile)
     end
 
 
     private
 
-    def dump_json(datapath, filename, basename, oed)
-      entry          = MiddleEnglishDictionary::Entry.new_from_xml_file(filename)
-      entry.oedlink  = oed[entry.id]
-      json_file_name = datapath + 'json' + "#{basename}.json"
-      File.open(json_file_name, 'w:utf-8') {|out| out.puts entry.to_json}
-    rescue MiddleEnglishDictionary::FileNotFound,
-           MiddleEnglishDictionary::FileEmpty,
-           MiddleEnglishDictionary::InvalidXML => e
-      logger.error e.message
-    rescue => e
-      puts e
-      require 'pry'; binding.pry
 
-      puts "Error in #{entry.source}"
-    end
+      # @param [Pathname] xmlfilepath Path to the xml file being processed
+      # @param [MiddleEnglishDictionary::Collection::OEDLinkSet] oedlinks
+      # @return MiddleEnglishDictionary::Entry
+      def create_and_fill_entry(xmlfilepath:, oedlinks:)
+        entry         = MiddleEnglishDictionary::Entry.new_from_xml_file(xmlfilepath)
+        entry.oedlink = oedlinks[entry.id]
+        entry
+      rescue MiddleEnglishDictionary::FileNotFound,
+          MiddleEnglishDictionary::FileEmpty,
+          MiddleEnglishDictionary::InvalidXML => e
+        logger.error e.message
+      rescue => e
+        puts e
+        require 'pry'; binding.pry
 
-
-    def start_new_letter(datapath, this_letter)
-      logger.info "Beginning work on words starting with #{this_letter}"
-      jdir = (datapath + 'json' + this_letter).to_s
-      FileUtils.mkpath(jdir) unless File.exists? jdir
-    end
-
-    def letter_and_filename(f)
-      m           = %r(xml/((.*?)/(.*))\.xml\Z).match(f)
-      this_letter = m[2]
-      this_file   = m[1]
-      return this_file, this_letter
-    end
-
-    def validate_xml_dir(datapath)
-      if Dir.exist?(datapath) and Dir.exist?(datapath + 'xml')
-        logger.info "Found xml directory at #{datapath + 'xml'}"
-      else
-        raise "Can't find xml directory at #{datapath + 'xml'}. Exiting"
+        puts "Error in #{entry.source}"
       end
-    end
+
+      def start_new_letter(datapath, this_letter)
+        logger.info "Beginning work on words starting with #{this_letter}"
+        jdir = (datapath + 'json' + this_letter).to_s
+        FileUtils.mkpath(jdir) unless File.exists? jdir
+      end
+
+
+      def letter_and_filename(f)
+        m           = %r(xml/((.*?)/(.*))\.xml\Z).match(f)
+        this_letter = m[2]
+        this_file   = m[1]
+        return this_file, this_letter
+      end
+
+
+      def validate_xml_dir(datapath)
+        if Dir.exist?(datapath) and Dir.exist?(datapath + 'xml')
+          logger.info "Found xml directory at #{datapath + 'xml'}"
+        else
+          raise "Can't find xml directory at #{datapath + 'xml'}. Exiting"
+        end
+      end
   end
 end

--- a/lib/med_installer/indexer/entry_json_reader.rb
+++ b/lib/med_installer/indexer/entry_json_reader.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 # From the traject docs:
 # #  A Reader is any class that:
 #   1) Has a two-argument initializer taking an IO stream and a Settings hash
@@ -31,24 +33,31 @@ module MedInstaller
 
   class EntryJsonReader
 
+    include Enumerable
     include MedInstaller::Logger
 
-    DATADIRKEY = 'med.data_dir'
-    LETTERSKEY = 'med.letters'
+    DATADIRKEY  = 'med.data_dir'
+    DATAFILEKEY = 'med.data_file'
+    LETTERSKEY  = 'med.letters'
 
     def initialize(settings)
-      @data_dir   = get_data_dir(settings)
-      @letters    = get_letters(settings)
-      @target_dirs = AnnoyingUtilities.target_directories(@data_dir, 'json', @letters)
+      @data_file = get_data_file(settings)
+      @letters   = get_letters(settings)
     end
 
     def each
-      @target_dirs.each do |dir|
-        entries     = MiddleEnglishDictionary::Collection::EntrySet.new
-        logger.info "Loading #{dir}"
-        entries.load_dir_of_json_files(dir)
-        logger.info "Indexing #{dir}"
-        entries.each {|e| yield e}
+      if @letters
+        letter_match = Regexp.new "\\A[#{@letters.join('')}]"
+        last_letter  = @letters.map(&:downcase).sort.last
+      end
+
+      File.open(@data_file).each do |json_line|
+        json_hash = JSON.parse(json_line)
+        if @letters
+          next unless json_hash['headwords'].any? {|x| letter_match.match(x)}
+          last if json_hash['headword'].first[0] > last_letter
+        end
+        yield MiddleEnglishDictionary::Entry.from_json(json_line)
       end
     end
 
@@ -56,15 +65,17 @@ module MedInstaller
       if settings.has_key?(LETTERSKEY)
         settings[LETTERSKEY]
       else
-        '[A-Z]'
+        nil
       end
     end
 
-    def get_data_dir(settings)
-      if settings.has_key?(DATADIRKEY)
-        settings[DATADIRKEY]
+    def get_data_file(settings)
+      if settings.has_key?(DATAFILEKEY)
+        Pathname.new(settings[DATAFILEKEY])
+      elsif settings.has_key[DATADIRKEY]
+        Pathname.new(settings[DATADIRKEY]) + 'entrires.json'
       else
-        raise "Need to specify #{DATADIRKEY} in settings for #{self.class}"
+        raise "Need to specify filename in #{DATAFILEKEY} or directory that holds 'entries.json' in #{DATADIRKEY} in settings for #{self.class}"
       end
     end
   end


### PR DESCRIPTION
The creation and lookup of many json files was a real
burden on the system and made for a very painful
deployment. This changes it to a single ndj file
to hold all the serialized entries.