### PR TITLE
Fix solr suggesters

### DIFF
--- a/solr/med/conf/schema.xml
+++ b/solr/med/conf/schema.xml
@@ -207,6 +207,7 @@
   <!--Definitions and modern equivalents-->
   <field name="definition_text"   type="text"    indexed="true" stored="true" multiValued="true"/>
   <field name="oed_norm" type="text" indexed="true" stored="true" multiValued="false"/>
+  <field name="doe_norm" type="me_text" indexed="true" stored="true" multiValued="false"/>
 
   <!-- Notes -->
   <field name="notes" type="text" indexed="true" stored="true" multiValued="true"/>

--- a/solr/med/conf/solrconfig.xml
+++ b/solr/med/conf/solrconfig.xml
@@ -10,6 +10,7 @@
         <!ENTITY headword_only_suggester SYSTEM "solrconfig_med/suggesters/headword_only_suggester.xml">
         <!ENTITY headword_and_forms_suggester SYSTEM "solrconfig_med/suggesters/headword_and_forms_suggester.xml">
         <!ENTITY oed_suggester SYSTEM "solrconfig_med/suggesters/oed_suggester.xml">
+        <!ENTITY doe_suggester SYSTEM "solrconfig_med/suggesters/doe_suggester.xml">
         ]>
 
 <config>
@@ -90,10 +91,12 @@
 
   &headword_only_suggester;
 
-  <!--Mount Oxford English Dictionary modern english suggester at /oed/suggester-->
+  <!--Mount Oxford English Dictionary modern english suggester at /oed_suggester-->
 
   &oed_suggester;
 
+<!-- Ditto for the Dictionary of Old English at /doe_suggester-->
+  &doe_suggester;
 
 
 

--- a/solr/med/conf/solrconfig_med/suggesters/doe_suggester.xml
+++ b/solr/med/conf/solrconfig_med/suggesters/doe_suggester.xml
@@ -1,10 +1,10 @@
-<searchComponent name="oed_suggester" class="solr.SuggestComponent">
+<searchComponent name="doe_suggester" class="solr.SuggestComponent">
 <lst name="suggester">
-  <str name="name">oed_suggester</str>
+  <str name="name">doe_suggester</str>
   <str name="lookupImpl">FSTLookupFactory</str>
-  <str name="suggestAnalyzerFieldType">me_text</str>
+  <str name="suggestAnalyzerFieldType">exactish</str>
   <str name="buildOnCommit">true</str>
-  <str name="field">oed_norm</str>
+  <str name="field">doe_norm</str>
   <str name="exactMatchFirst">true</str>
   <str name="buildOnStartup">true</str>
   <str name="minPrefixChars">2</str>
@@ -13,14 +13,14 @@
 </lst>
 </searchComponent>
 
-<requestHandler name="/oed_suggester" class="solr.SearchHandler"
+<requestHandler name="/doe_suggester" class="solr.SearchHandler"
                 startup="lazy">
 <lst name="defaults">
   <str name="suggest">true</str>
   <str name="suggest.count">15</str>
-  <str name="suggest.dictionary">oed_suggester</str>
+  <str name="suggest.dictionary">doe_suggester</str>
 </lst>
 <arr name="components">
-  <str>oed_suggester</str>
+  <str>doe_suggester</str>
 </arr>
 </requestHandler>


### PR DESCRIPTION
Fix oed suggester to use non-borked suggest hander, and add one for doe (including field doe_norm in schema)

Note: requires a reload of the solr core (`bin/dromedary solr reload`). 