### PR TITLE
add basic bibliography controller

### DIFF
--- a/app/assets/javascripts/bibliography.coffee
+++ b/app/assets/javascripts/bibliography.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/bibliography.scss
+++ b/app/assets/stylesheets/bibliography.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Bibliography controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/bibliography_controller.rb
+++ b/app/controllers/bibliography_controller.rb
@@ -1,0 +1,37 @@
+class BibliographyController < ApplicationController
+
+ include Blacklight::Catalog
+
+ configure_blacklight do |config|
+    ## Class for sending and receiving requests from a search index
+    # config.repository_class = Blacklight::Solr::Repository
+    #
+    ## Class for converting Blacklight's url parameters to into request parameters for the search index
+    # config.search_builder_class = ::SearchBuilder
+    #
+    ## Model that maps search index responses to the blacklight response model
+    # config.response_model = Blacklight::Solr::Response
+
+
+    #----------------------------------------------------------
+    #   Dromedary-only stuff
+    #----------------------------------------------------------
+    # config.add_nav_action(:search, partial: 'shared/nav/search')
+    config.add_nav_action(:about, partial: 'shared/nav/about')
+    config.add_nav_action(:help, partial: 'shared/nav/help')
+    config.add_nav_action(:contact, partial: 'shared/nav/contact')
+
+    config.navbar.partials.delete(:search_history)
+
+    # Show page tools items
+    #add_show_tools_partial(:print)
+    config.show.document_actions.delete(:email)
+    config.show.document_actions.delete(:sms)
+	end
+
+  def index
+  end
+
+  def show
+  end
+end

--- a/app/controllers/bibliography_controller.rb
+++ b/app/controllers/bibliography_controller.rb
@@ -30,8 +30,10 @@ class BibliographyController < ApplicationController
 	end
 
   def index
+    @current_action = 'bibliography'
   end
 
   def show
+    @current_action = 'bibliography'
   end
 end

--- a/app/helpers/bibliography_helper.rb
+++ b/app/helpers/bibliography_helper.rb
@@ -1,0 +1,2 @@
+module BibliographyHelper
+end

--- a/app/views/bibliography/index.html.erb
+++ b/app/views/bibliography/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Bibliography#index</h1>
+<p>Find me in app/views/bibliography/index.html.erb</p>

--- a/app/views/bibliography/show.html.erb
+++ b/app/views/bibliography/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Bibliography#show</h1>
+<p>Find me in app/views/bibliography/show.html.erb</p>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -20,26 +20,21 @@
       </div>
     </div>
 
-    <% puts "CURRENT ACTION IS: #{@current_action} =========================================" %>
+    <div id="header-navbar-secondary" class="navbar navbar-inverse navbar-static-top" role="navigation" style="background-color: lightblue;">
+      <div class="container container--full site-header-container">
+        <button type="button" class="navbar-toggle btn collapsed" data-toggle="collapse" data-target="#secondary-util-collapse">
 
-      <div id="header-navbar-secondary" class="navbar navbar-inverse navbar-static-top" role="navigation" style="background-color: lightblue;">
-
-        <div class="container container--full site-header-container">
-
-              <button type="button" class="navbar-toggle btn collapsed" data-toggle="collapse" data-target="#secondary-util-collapse">
-
-           <button type="button" class="navbar-toggle btn collapsed" data-toggle="collapse" data-target="#secondary-util-collapse">
+        <button type="button" class="navbar-toggle btn collapsed" data-toggle="collapse" data-target="#secondary-util-collapse">
           <span class="sr-only">Toggle navigation</span>
           <span class="icon-bar"></span>
-          </button>
+        </button>
 
-          <div class="collapse navbar-collapse" id="secondary-util-collapse">
-              <%= render :partial=>'/secondary_util_links' %>
-          </div>
+        <div class="collapse navbar-collapse" id="secondary-util-collapse">
+            <%= render :partial=>'/secondary_util_links' %>
         </div>
       </div>
-
     </div>
+
   </div>
 </header>
 

--- a/app/views/shared/nav/_bib.html.erb
+++ b/app/views/shared/nav/_bib.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "Bibliography", {:controller => "catalog", :action => "index"} %>
+<%= link_to "Bibliography", {:controller => "bibliography", :action => "index"} %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
   
+  get 'bibliography/index'
+
+  get 'bibliography/show'
+
   mount Blacklight::Engine => '/'
 
   root to: "catalog#home"

--- a/spec/controllers/bibliography_controller_spec.rb
+++ b/spec/controllers/bibliography_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe BibliographyController, type: :controller do
+
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET #show" do
+    it "returns http success" do
+      get :show
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/helpers/bibliography_helper_spec.rb
+++ b/spec/helpers/bibliography_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the BibliographyHelper. For example:
+#
+# describe BibliographyHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe BibliographyHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/bibliography/index.html.erb_spec.rb
+++ b/spec/views/bibliography/index.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "bibliography/index.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/bibliography/show.html.erb_spec.rb
+++ b/spec/views/bibliography/show.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "bibliography/show.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
**This PR:**

- Adds a very basic controller for the bibliography
- And once solr is set up to search for bib data we can extend the new controller
- Then app/views/bibliography/[index, show].html.erb files can get real content
- And we can add other files to views/ as needed.
- Also cleans up the app/views/shared/_header_navbar.html.erb file.