### PR TITLE
move tilde replacement w/ headword into display code; turn off unneed…

### DIFF
--- a/app/helpers/med_quotes_helper.rb
+++ b/app/helpers/med_quotes_helper.rb
@@ -20,18 +20,18 @@ module MedQuotesHelper
             cite_quote_text =  get_quote_value(cite.quote.text)
             cite_link = "https://quod.lib.umich.edu/cgi/m/mec/hyp-idx?type=id&id=#{sten_rid}"
 
-            Rails.logger.debug "sten_date: " + sten_date
-            Rails.logger.debug "sten_title: " + sten_title
-            Rails.logger.debug "sten_ms: " + sten_ms
-            Rails.logger.debug "sten_rid: " + sten_rid
-            Rails.logger.debug "cite_bib_scope: " + cite_bib_scope
-            Rails.logger.debug "cite_quote_text: " + cite_quote_text
-            Rails.logger.debug "cite_link: " + cite_link
+            # Rails.logger.debug "sten_date: " + sten_date
+            # Rails.logger.debug "sten_title: " + sten_title
+            # Rails.logger.debug "sten_ms: " + sten_ms
+            # Rails.logger.debug "sten_rid: " + sten_rid
+            # Rails.logger.debug "cite_bib_scope: " + cite_bib_scope
+            # Rails.logger.debug "cite_quote_text: " + cite_quote_text
+            # Rails.logger.debug "cite_link: " + cite_link
 
             quote_str = '<a href="' + cite_link + '" > ' + sten_date + ' ' + sten_title
             quote_str = quote_str + sten_ms + '</a> ' + cite_bib_scope + ' ' + cite_quote_text
 
-            Rails.logger.debug "quote_str: " + quote_str
+            # Rails.logger.debug "quote_str: " + quote_str
 
             subdef_arr.push quote_str
           end # citations.each

--- a/app/presenters/dromedary/index_presenter.rb
+++ b/app/presenters/dromedary/index_presenter.rb
@@ -36,8 +36,15 @@ module Dromedary
     # @return [Array<MiddleEnglishDictionary::Sense>] All the entry senses
     # modified to replace '~' with regularized headword
     def senses
+      binding.pry
       headw = @entry.headwords.first.instance_variable_get(:@regs).first
-      @entry.senses.each { |sen| sen.definition_xml.gsub! '~', headw}
+      # @entry.senses.each { |sen| sen.definition_xml.gsub! '~', headw}
+      puts "HEADWORD: #{headw}"
+      @entry.senses.each do |s|
+        puts "BEFORE FIX SENSE XML: #{s.definition_xml}"
+        s.definition_xml.gsub! '~', headw
+        puts "AFTER FIX: #{s.definition_xml}"
+      end
       @entry.senses
     end
 

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -43,6 +43,11 @@
                   <% def_xml = Nokogiri::XML(sen.definition_xml) %>
                   <% def_xslt = Nokogiri::XSLT(File.read('./indexer/xslt/DefOnly.xsl'))%>
                   <% current_def = def_xslt.apply_to(def_xml) %>
+
+                  <!-- Moved from the index_presenter because ent.senses wasn't calling it -->
+                  <% headw = ent.headwords.first.instance_variable_get(:@regs).first %>
+                  <% current_def =  current_def.gsub! '~', headw %>
+
                   <%== current_def %>
                 </td>
                 <td  class="quote-control">


### PR DESCRIPTION
- The senses def in the drome index_presenter is not longer being called and I can't tell why
- I've moved the tilde replacement w/ headword into display code (app/views/catalog/_show_default.html.erb)
- And I turned off unneeded logging in med_quotes_helper.rb