### PR TITLE
modify show page to use doc_presenter.part_of_speech_abbrev

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
     marc-fastxmlwriter (1.0.0)
       marc (~> 1.0)
     method_source (0.9.0)
-    middle_english_dictionary (1.0.2)
+    middle_english_dictionary (1.0.3)
       multi_json
       nokogiri (~> 1.6)
       representable
@@ -338,7 +338,7 @@ DEPENDENCIES
   jquery-rails
   listen
   mail_form (= 1.7.0)
-  middle_english_dictionary (= 1.0.2)
+  middle_english_dictionary (= 1.0.3)
   mysql2 (< 0.5.0)
   nestive (= 0.6.0)
   nokogiri

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -10,7 +10,7 @@
 
   <%# Get headword and display it with quotes hide/show %>
   <div class="entry-heading">
-    <div class="entry-headword"><%= ent.original_headwords.first %>&nbsp;(<span class="entry-pos"><%= ent.pos_raw %>)</span></div>
+    <div class="entry-headword"><%= ent.original_headwords.first %>&nbsp;(<span class="entry-pos"><%= doc_presenter.part_of_speech_abbrev %>)</span></div>
     <div class="quotations-header-options">Quotations: <a href="#" onClick="function show_quotes(){ $( 'tr.quotes' ).show();   } show_quotes(); return false;">Show All</a> <a href="#" onClick="function hide_quotes(){ $( 'tr.quotes' ).hide();  } hide_quotes(); return false;">Hide All</a></div>
   </div>
 
@@ -93,7 +93,7 @@
   <% show_sups = ! sups.empty? if show_sups %>
 
   <% if show_sups %>
-    <h3 class="entry-supplemental-title">Supplemental Notes</h3>
+    <h3 class="entry-supplemental-title">Supplemental Materials (draft)</h3>
 
     <div class="table-responsive entry-supliment">
       <table class="table">


### PR DESCRIPTION
This PR:

- Changes Gemfile.lock middle_english_dictionary version from 1.0.2 to 1.0.3
- Modified app/views/catalog/_show_default.html.erb to use doc_presenter.part_of_speech_abbrev instead of ent.pos_raw since the later is no longer available.
- Also fixed title of the supplements section to be @pfs' desired title.