### PR TITLE
DO NOT MERGE - TESTING WIP add conditional facets display for quotes

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -65,8 +65,11 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
+    
     config.add_sort_field 'score desc', label: 'Relevance'
-    config.add_sort_field 'sequence asc', label: 'Alphabetical'
+    config.add_sort_field 'sequence asc', label: 'Alphabetical', if: :not_displaying_quotes? 
+    config.add_sort_field 'date asc', label: 'Date', if: :displaying_quotes? 
+
 
     ##--------------------------------------------------------
     # The search results (index) page
@@ -85,6 +88,9 @@ class CatalogController < ApplicationController
     # How should we choose how to display this item? (maybe not used if
     # you only have one type of record)
     config.index.display_type_field = "type"
+    
+    # config.index.display_type_field = 'quote_text', label: 'Quotation Text'
+
 
     # Add fields to the display
     # config.add_index_field 'orths', label: "Other forms"
@@ -124,9 +130,13 @@ class CatalogController < ApplicationController
     #  (useful when user clicks "more" on a large facet and wants to navigate alphabetically across a large set of results)
     # :index_range can be an array or range of prefixes that will be used to create the navigation (note: It is case sensitive when searching values)
 
-    config.add_facet_field 'pos_abbrev', label: 'Part of Speech'
-    config.add_facet_field 'discipline_usage', label: "Professional Usage"
-    config.add_facet_field 'etyma_language', label: "Source Language"
+    config.add_facet_field 'pos_abbrev', label: 'Part of Speech', if: :not_displaying_quotes? 
+    config.add_facet_field 'discipline_usage', label: "Professional Usage", if: :not_displaying_quotes? 
+    config.add_facet_field 'etyma_language', label: "Source Language", if: :not_displaying_quotes? 
+
+    config.add_facet_field 'headword', label: "Headwords", if: :displaying_quotes? 
+
+    config.add_facet_field 'quote_title', label: 'Quotation Title', if: :displaying_quotes? 
 
     #     config.add_facet_field 'subject_topic_facet', label: 'Topic', limit: 20, index_range: 'A'..'Z'
     #     config.add_facet_field 'example_pivot_field', label: 'Pivot Field', :pivot => ['format', 'language_facet']
@@ -317,5 +327,20 @@ class CatalogController < ApplicationController
         search_component_name: "oed_suggester"
       }
     }
+  end
+
+
+  def displaying_quotes?
+    search_field_test = params[:search_field]
+    puts "SEARCH FIELD IS " + search_field_test.to_s
+    puts "PARAMS ARE:"
+    puts params
+    tf =  params[:search_field] == 'h' ? true : false
+    puts "TF is: " + tf.to_s
+    return tf
+  end
+
+  def not_displaying_quotes?
+    ! displaying_quotes?
   end
 end

--- a/app/controllers/concerns/catalog.rb
+++ b/app/controllers/concerns/catalog.rb
@@ -8,22 +8,6 @@ module Dromedary::Catalog
   # get search results from the solr index
   def index
     @current_action = 'dictionary'
-
-    (@response, @document_list) = search_results(params)
-    respond_to do |format|
-      format.html { } # no longer store_preferred_view
-      format.rss  { render :layout => false }
-      format.atom { render :layout => false }
-      format.json do
-        @presenter = Blacklight::JsonPresenter.new(@response,
-                                                   @document_list,
-                                                   facets_from_request,
-                                                   blacklight_config)
-      end
-
-      # additional_response_formats(format)
-      # document_export_formats(format)
-    end
   end
 
   def search
@@ -38,5 +22,6 @@ module Dromedary::Catalog
     @current_action = 'home'
     render :layout => 'home'
   end
+
 
 end

--- a/app/views/catalog/_index_header_quote.html.erb
+++ b/app/views/catalog/_index_header_quote.html.erb
@@ -1,0 +1,62 @@
+<%# header bar for doc items in index view -%>
+<div class="documentHeader row">
+  <%# main title container for doc partial view
+      How many bootstrap columns need to be reserved
+      for bookmarks control depends on size.
+  -%>
+  <% doc_presenter = index_presenter(document) %>
+  <% entry = doc_presenter.entry %>
+
+  <% document_actions = capture do %>
+    <% # bookmark functions for items/docs                -%>
+    <%= render_index_doc_actions document, wrapping_class: "index-document-functions col-sm-3 col-lg-2" %>
+  <% end %>
+
+  <h3 class="index_title document-title-heading <%= document_actions.present? ? "col-sm-9 col-lg-10" : "col-md-12" %>">
+    <% if counter = document_counter_with_offset(document_counter) %>
+      <span class="document-counter">
+        <%= t('blacklight.search.documents.counter', counter: counter) %>
+      </span>
+    <% end %>
+    <%= link_to_document document, doc_presenter.highlighted_official_headword, counter: counter %>
+    (<%== doc_presenter.part_of_speech_abbrev %>)
+  </h3>
+
+  <div class="search-result def col-md-12">
+    <% if hos = doc_presenter.highlighted_other_spellings && hos.count > 0 %>
+      <div>Additional spellings: <%== hos.join(', ') %></div>
+    <% end %>
+
+    <div class="index-quotes-line">
+      <%# quote_count = doc_presenter.quote_count %>
+      <%#= "#{doc_presenter.quote_count} quotation".pluralize(doc_presenter.quote_count) + " in #{doc_presenter.senses.count}" + " sense".pluralize(doc_presenter.senses.count) + " definition".pluralize(doc_presenter.senses.count)%>
+    </div>
+    <% if doc_presenter.quotes.count == 1 %>
+      <div>
+        <% sense = doc_presenter.quotes.first %>
+        <% def_xml = Nokogiri::XML(sense.definition_xml) %>
+        <% def_xslt = Nokogiri::XSLT(File.read('./indexer/xslt/DefOnly.xsl'))%>
+        <% current_def = "<span class='index-definition-tag'>Definition (1st sense) </span>" + def_xslt.apply_to(def_xml) %>
+        <div class="index-definition"><%== current_def %></div>
+
+      </div>
+    <% else %>
+      <ol>
+        <% doc_presenter.senses.each do |sense| %>
+          <li>
+            <% def_xml = Nokogiri::XML(sense.definition_xml) %>
+            <% def_xslt = Nokogiri::XSLT(File.read('./indexer/xslt/DefOnly.xsl'))%>
+            <% current_def = def_xslt.apply_to(def_xml) %>
+            <div class="index-definition"><%== current_def %></div>
+          </li>
+        <% end %>
+      </ol>
+
+    <% end %>
+
+  </div>
+
+
+
+  <%= document_actions %>
+</div>

--- a/app/views/catalog/_index_quote.html.erb
+++ b/app/views/catalog/_index_quote.html.erb
@@ -1,0 +1,15 @@
+<%# default partial to display solr document fields in catalog index view -%>
+<%#= render partial: 'catalog/document_header', locals: { document: document } %>
+<%#= render_plain_text(document, 'page_text', breaks: false) %>
+<% doc_presenter = index_presenter(document) %> 
+<%# default partial to display solr document fields in catalog index view -%>
+<dl class="document-metadata dl-horizontal dl-invert">
+  
+  <% index_fields(document).each do |field_name, field| -%>
+    <% if should_render_index_field? document, field %>
+	    <dt class="blacklight-<%= field_name.parameterize %>"><%= render_index_field_label document, field: field_name %></dt>
+	    <dd class="blacklight-<%= field_name.parameterize %>"><%= doc_presenter.field_value field_name %></dd>
+    <% end -%>
+  <% end -%>
+
+</dl>

--- a/app/views/catalog/_show_quote.html.erb
+++ b/app/views/catalog/_show_quote.html.erb
@@ -1,0 +1,109 @@
+<%# doc_presenter = show_presenter(document) %>
+<% doc_presenter = index_presenter(document) %>
+<% ent = doc_presenter.entry %>
+
+<%# default partial to display solr document fields in catalog show view -%>
+<div class="entry-panel">
+  
+  <%# Display Heading for MED Entry %>
+  <h2 class="entry-main-title">Middle English Dictionary Entry</h2>
+
+  <%# Get headword and display it with quotes hide/show %>
+  <div class="entry-heading">
+    <div class="entry-headword"><%= ent.original_headwords.first %>&nbsp;(<span class="entry-pos"><%= ent.pos_raw %>)</span></div>
+    <div class="quotations-header-options">Quotations: <a href="#" onClick="function show_quotes(){ $( 'tr.quotes' ).show();   } show_quotes(); return false;">Show All</a> <a href="#" onClick="function hide_quotes(){ $( 'tr.quotes' ).hide();  } hide_quotes(); return false;">Hide All</a></div>
+  </div>
+
+  <%# Get get forms and etymology and display %>
+  <div>
+      <h3 class="entry-intro-title">Entry Info</h3>
+  </div>
+
+  <div class="table-responsive entry-info">
+    <table class="table">
+      <tr><td class="forms-title">Forms</td><td class="forms-list"><% ent.all_forms.each_with_index do |(k, v)|  %><%= k %><%= "," if k != ent.all_forms.last %>&nbsp;&nbsp;<% end %></td></tr>
+      <tr><td class="etymology-title">Etymology</td><td class="etymology-list">
+          <% etym_xml = Nokogiri::XML(ent.etym_xml) %>
+          <% etym_xslt = Nokogiri::XSLT(File.read('./indexer/xslt/EtymOnly.xsl'))%>
+          <% current_etym = etym_xslt.apply_to(etym_xml) %>
+          <%== current_etym %>
+      </td></tr>
+    </table>
+  </div>
+
+  <%# Get get senses plus their quotes and display %>
+  <h3 class="entry-senses-title">Senses and Subsenses</h3>
+
+  <div class="table-responsive entry-senses">
+    <table class="table">
+        <% doc_presenter.senses.each do |sen|  %>
+            <tr>
+                <td class="senses-index"><%= sen.sense_number.to_s %></td>
+                	<td class="senses-defintion">
+                  <% def_xml = Nokogiri::XML(sen.definition_xml) %>
+                  <% def_xslt = Nokogiri::XSLT(File.read('./indexer/xslt/DefOnly.xsl')) %>
+                  <% current_def = def_xslt.apply_to(def_xml) %>
+                  <%== current_def %>
+                </td>
+                <td  class="quotes-control">
+
+                  <% jq_sense = "tr.sense_id_" + sen.sense_number.to_s  %>
+                  <% quotes, quote_count = med_quotes_help(sen) %>
+
+                  <% if !quotes.empty? && quote_count > 0 %>
+                    <% quote_show_string = (quote_count == 1) ?  "Show Quote" : "Show #{quote_count} " + "Quote".pluralize(quote_count) %>
+
+                    <div class="quotes-show"><a href="#" onClick='function show_def_quotes(){ $( "<%= jq_sense %>" ).show();   } show_def_quotes(); return false;'><%== quote_show_string %></a></div>
+
+                    <div class="quotes-hide"><a href="#" onClick='function hide_def_quotes(){ $("<%= jq_sense %>" ).hide();   } hide_def_quotes(); return false'><%== "Hide " + "Quote".pluralize(quote_count) %></a>
+                    </div>
+                  </td>
+                  <% end %>
+              </tr>
+
+              <%# class quotes can be used to hide/show all quotes; class q_id_n does the same for individual definition's quotes %>
+                <% if !quotes.empty? && quote_count > 0 %>
+                <% last_subdef_index_index = "" %>
+                <% quotes.each do |subdef_index, q_arr| %>
+                  <% q_arr.each do |q| %>
+                    <tr  class="quotes sense_id_<%= sen.sense_number.to_s %>">
+
+                    <td>
+                      <% if subdef_index != last_subdef_index_index %>
+                        <% last_subdef_index_index = subdef_index %>
+                        <span class="subdef-index"><%== subdef_index %>
+                      <% end %>
+                    </td>
+
+                    <td><%== q %></td >
+
+                  </tr>
+                  <% end %>
+                <% end %>
+              <% end %>
+
+        	<% end %>
+    </table>
+  </div>
+
+  <%# Get supplement and display %>
+  <% sups = ent.instance_variable_get(:@supplements) %>
+  <% show_sups = true %>
+  <% show_sups = ! sups.nil? %>
+  <% show_sups = ! sups.empty? if show_sups %>
+
+  <% if show_sups %>
+    <h3 class="entry-supplemental-title">Supplemental Notes</h3>
+
+    <div class="table-responsive entry-supliment">
+      <table class="table">
+          <% sups.each do |sup|  %>
+            <tr>
+                <td><%== sup.instance_variable_get(:@notes).first  %></td>
+          	</tr>
+          <% end %>
+      </table>
+    </div>
+  <% end %>
+
+</div>


### PR DESCRIPTION
**This branch adds:**

1. Conditional facets based on params[:search_field] in app/controllers/catalog_controller.rb
2. When the search_field == 'h' alternative facets and sort options are used, 'h' being a stand in for the quote search_field
3. Some new app/views/catalog/ quote view files are added too based on web page: https://github.com/projectblacklight/blacklight/wiki/Configuration---Results-View#partials-and-display_type_field
4. We will need to test all these options further when the revised index_presenter with quotes is ready