### PR TITLE
New indexing framework and OED/DOE changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,10 +12,10 @@ end
 # When developing in tandem, a relative path is nice and easy
 
 # gem 'middle_english_dictionary', path: "/Users/dueberb/devel/med/middle_english_dictionary"
-gem 'middle_english_dictionary', '=1.0.3'
+gem 'middle_english_dictionary', '=1.1.0'
 
 
-# Rails and blacklight
+# Rails and blacklight and such
 
 gem 'rails', '~> 5.1.4'
 gem 'blacklight', "~> 6.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
     marc-fastxmlwriter (1.0.0)
       marc (~> 1.0)
     method_source (0.9.0)
-    middle_english_dictionary (1.0.2)
+    middle_english_dictionary (1.1.0)
       multi_json
       nokogiri (~> 1.6)
       representable
@@ -338,7 +338,7 @@ DEPENDENCIES
   jquery-rails
   listen
   mail_form (= 1.7.0)
-  middle_english_dictionary (= 1.0.2)
+  middle_english_dictionary (= 1.1.0)
   mysql2 (< 0.5.0)
   nestive (= 0.6.0)
   nokogiri

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -124,7 +124,7 @@ class CatalogController < ApplicationController
     #  (useful when user clicks "more" on a large facet and wants to navigate alphabetically across a large set of results)
     # :index_range can be an array or range of prefixes that will be used to create the navigation (note: It is case sensitive when searching values)
 
-    config.add_facet_field 'pos_abbrev', label: 'Part of Speech'
+    config.add_facet_field 'pos', label: 'Part of Speech'
     config.add_facet_field 'discipline_usage', label: "Professional Usage"
     config.add_facet_field 'etyma_language', label: "Source Language"
 
@@ -147,8 +147,7 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
     config.add_show_field 'headword', label: 'Headwords'
-    config.add_show_field 'pos_abbrev', label: 'Gramatical Usage (POS ABBREV)'
-    config.add_show_field 'pos_raw', label: 'Gramatical Usage (POS RAW)'
+    config.add_show_field 'pos_abbrev', label: 'Part of Speech'
     config.add_show_field 'discipline_usage', label: 'Professional Usage'
     config.add_show_field 'etyma_language', label: 'Source Language'
     config.add_show_field 'definition_text', label: 'Definition Text'

--- a/app/presenters/dromedary/index_presenter.rb
+++ b/app/presenters/dromedary/index_presenter.rb
@@ -30,7 +30,7 @@ module Dromedary
 
     # @return [String] The cleaned-up POS abbreviation (e.g., "n" or "v")
     def part_of_speech_abbrev
-      @document.fetch('pos_abbrev')
+      @entry.pos
     end
 
     # @return [Array<MiddleEnglishDictionary::Sense>] All the entry senses
@@ -81,3 +81,4 @@ module Dromedary
 
   end
 end
+

--- a/app/views/catalog/_related_entries.html.erb
+++ b/app/views/catalog/_related_entries.html.erb
@@ -1,14 +1,37 @@
 <% doc_presenter = index_presenter(@document) %>
 <% ent = doc_presenter.entry %>
 
-<% if ! ent.oedlink.nil? %>
-	<div class="panel panel-default show-related">
-	  <div class="panel-heading">Related Dictionary Entries</div>
-	   <div class="panel-body">
-	   	<p class="oed-subscription-warning">Please note that the OED is a subscription resource</p>
+<% if ent.oedlinks or ent.doelinks %>
+  <div class="panel panel-default show-related">
+    <div class="panel-heading">Related Dictionary Entries</div>
+    <div class="panel-body">
 
-	   	<% oed_href = "http://www.oed.com/view/Entry/#{ent.oedlink.oed_id}" %>
-	   	<a class="oed-link" href=<%= oed_href %> >(OED) <%== ent.oedlink.oed_head %></a>
-	  	</div>
-	</div>
+      <% if ent.oedlinks %>
+        <div class="related-link-subhead">Oxford English Dictionary</div>
+        <p class="oed-subscription-warning">Please note that the OED is a
+          subscription resource</p>
+        <ul>
+          <% ent.oedlinks.each do |elink| %>
+            <% oed_href = "http://www.oed.com/view/Entry/#{elink.target_id}" %>
+            <li>
+              <a class="external-link" href=<%= oed_href %>><%== elink.term %></a>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+
+      <% if ent.doelinks %>
+        <div class="related-link-subhead">Dictionary of Old English</div>
+        <ul>
+          <% ent.doelinks.each do |elink| %>
+            <% oed_href = "http://tapor.library.utoronto.ca/doe/?E#{elink.target_id}" %>
+            <li>
+              <a class="external-link" href=<%= oed_href %>><%== elink.term %></a>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+
+    </div>
+  </div>
 <% end %>

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -10,7 +10,7 @@
 
   <%# Get headword and display it with quotes hide/show %>
   <div class="entry-heading">
-    <div class="entry-headword"><%= ent.original_headwords.first %>&nbsp;(<span class="entry-pos"><%= ent.pos_raw %>)</span></div>
+    <div class="entry-headword"><%= ent.original_headwords.first %>&nbsp;(<span class="entry-pos"><%= ent.pos %>)</span></div>
     <div class="quotations-header-options">Quotations: <a href="#" onClick="function show_quotes(){ $( 'tr.quotes' ).show();   } show_quotes(); return false;">Show All</a> <a href="#" onClick="function hide_quotes(){ $( 'tr.quotes' ).hide();  } hide_quotes(); return false;">Hide All</a></div>
   </div>
 

--- a/bin/dromedary
+++ b/bin/dromedary
@@ -12,7 +12,8 @@ require "bundler/setup"
 
 # Add the local lib
 
-$LOAD_PATH.unshift Pathname(__dir__).parent + 'lib'
+$LOAD_PATH.unshift (Pathname(__dir__).parent + 'lib').to_s
+$LOAD_PATH.unshift (Pathname(__dir__).parent + 'indexer').to_s
 
 # Now we can actually load stuff
 require 'hanami/cli'

--- a/indexer/pry_session.rb
+++ b/indexer/pry_session.rb
@@ -29,6 +29,7 @@ settings = {
 }
 
 entries = MedInstaller::EntryJsonReader.new(settings)
+e = entries.first
 require 'pry'; binding.pry
 
 puts "Done"

--- a/indexer/quote/basic_rules.rb
+++ b/indexer/quote/basic_rules.rb
@@ -1,0 +1,78 @@
+require 'middle_english_dictionary'
+require 'securerandom'
+
+$LOAD_PATH.unshift Pathname.new(__dir__).parent + 'lib'
+require 'annoying_utilities'
+require 'med_installer'
+
+settings do
+  store "log.batch_size", 2_500
+  provide 'med.data_dir', Pathname(__dir__).parent.parent + 'data'
+  provide "reader_class_name", 'MedInstaller::Traject::EntryJsonReader'
+end
+
+
+# Do a terrible disservice to traject and monkeypatch it to take
+# our existing logger
+
+Traject::Indexer.send(:define_method, :logger, ->() {AnnoyingUtilities.logger})
+
+
+# For quotes, a record is a simple struct
+#   quote: <string>
+#   entry_id: "MED..."
+#   cd: date_of_creation.to_i,
+#   md: date_of_manuscript.to_i
+#   quote_html: html of the quote <string>,
+#   rid: rid for this stencil
+#   title: title of the stencil
+#   manuscript: manuscript abbreviation thing
+
+def lazy_method(name)
+  ->(rec, acc) {acc.replace Array(rec.send(name))}
+end
+
+to_field 'type' do |q, acc|
+  acc << 'quote'
+end
+
+to_field 'id' do |q, acc|
+  acc << SecureRandom.uuid
+end
+
+to_field 'entry_id', lazy_method(:entry_id)
+
+
+to_field 'quote_text', lazy_method(:quote)
+to_field 'quote_html', lazy_method(:quote_html)
+
+to_field 'cd', lazy_method(:cd)
+to_field 'md', lazy_method(:md)
+
+to_field 'rid', lazy_method(:rid)
+to_field "quote_manuscript", lazy_method(:ms)
+to_field "quote_date", lazy_method(:date)
+to_field "scope", lazy_method(:scope)
+
+to_field("citation_json") do |q, acc|
+  acc << q.citation.to_json
+end
+
+
+
+# def initialize(citation: citation)
+#   self.quote      = citation.quote.text
+#   self.entry_id   = citation.entry_id
+#   self.cd         = citation.cd
+#   self.md         = citation.md
+#   self.quote_html = XSLT.apply_to(Nokogiri::XML(citation.quote.xml))
+#   self.scope      = citation.bib.scope
+#
+#   stencil                = citation.bib.stencil
+#   self.rid               = stencil.rid
+#   self.date              = stencil.date
+#   self.title             = stencil.title
+#   self.manuscript_abbrev = stencil.ms
+#   self.citation_json     = citation.to_json
+# end
+#

--- a/indexer/quote/quote_indexer.rb
+++ b/indexer/quote/quote_indexer.rb
@@ -1,0 +1,47 @@
+require 'traject/indexer'
+
+module Dromedary
+  class QuoteIndexer
+
+    attr_accessor :settings, :indexer, :logger
+
+    def initialize(passed_settings = {})
+      index_dir        = AnnoyingUtilities::DROMEDARY_ROOT + 'indexer'
+      default_settings = {
+        'log.batch_size'    => 2_500,
+        "reader_class_name" => 'MedInstaller::Traject::EntryJsonReader',
+        "med.data_file"     => AnnoyingUtilities::DROMEDARY_ROOT.parent + 'data/entries.json.gz',
+        "solr_writer.batch_size" => 200,
+
+        writer_file:        index_dir + 'writers' + 'localhost.rb',
+        rule_files:         [Pathname(__dir__) + 'basic_rules.rb']
+      }
+      @settings        = default_settings.merge passed_settings
+      @logger          = AnnoyingUtilities.logger
+      create_indexer!(@settings)
+    end
+
+    def create_indexer!(settings = self.settings)
+      @indexer = Traject::Indexer.new(settings)
+      settings[:rule_files].each {|rf| @indexer.load_config_file(rf)}
+      @indexer.load_config_file(settings[:writer_file])
+      @indexer
+    end
+
+    def writer
+      indexer.writer
+    end
+
+    def put(record, position)
+      context = Traject::Indexer::Context.new(
+        :source_record => record,
+        :settings      => self.settings,
+        :position      => position,
+        :logger        => self.logger
+      )
+      indexer.map_to_context!(context) # side-effects the context
+      writer.put(context)
+    end
+  end
+
+end

--- a/indexer/writers/localhost.rb
+++ b/indexer/writers/localhost.rb
@@ -8,6 +8,6 @@ settings do
   provide "solr.url", AnnoyingUtilities.solr_url
   provide "solr_writer.commit_on_close", "true"
   provide "solr_writer.thread_pool", 2
-  provide "solr_writer.batch_size", 60
+  provide "solr_writer.batch_size", 200
   provide "writer_class_name", "Traject::SolrJsonWriter"
 end

--- a/lib/annoying_utilities.rb
+++ b/lib/annoying_utilities.rb
@@ -20,6 +20,16 @@ module AnnoyingUtilities
     DROMEDARY_ROOT
   end
 
+  def indexer_dir
+    dromedary_root + 'indexer'
+  end
+
+  def xslt_dir
+    indexer_dir + 'xslt'
+  end
+
+
+
   def blacklight_solr_url(env = nil)
     env       ||= ENV['RAILS_ENV'] || ENV['RAILS_ENVIRONMENT'] || 'development'
     @solr_url ||= load_config_file('blacklight.yml')[env]['url']

--- a/lib/med_installer/convert.rb
+++ b/lib/med_installer/convert.rb
@@ -2,6 +2,7 @@ require 'middle_english_dictionary'
 require 'hanami/cli'
 require 'tempfile'
 require 'zlib'
+require 'serialization/indexable_quote'
 
 module MedInstaller
   # Convert a bunch of Dromedary xml files into a more useful format.
@@ -14,109 +15,147 @@ module MedInstaller
     argument :letter, required: false, desc: "one letter to convert"
 
 
+    def most_recent_file(filenames)
+      filenames.sort {|a, b| File.mtime(a) <=> File.mtime(b)}.last
+    end
+
     def find_oed_file(datapath)
-      xmldir = datapath + 'xml'
-      xmldir.children.select {|x| x.to_s =~ /MED2OED/}.first
+      xmldir     = datapath + 'xml'
+      candidates = xmldir.children.select {|x| x.to_s =~ /MED2OED/}
+      most_recent_file(candidates)
+    end
+
+    def find_doe_file(datapath)
+      xmldir     = datapath + 'xml'
+      candidates = xmldir.children.select {|x| x.to_s =~ /MED2DOE/}.sort
+      most_recent_file(candidates)
     end
 
 
-    DIR_NAME_REGEX = Regexp.new "/xml/([A-Z][^/]*)/MED"
+    DIR_NAME_REGEX = Regexp.new "/xml/([A-Z12][^/]*)/MED"
 
 
     def call(datadir:, letter: nil)
       datapath = Pathname(datadir).realdirpath
       validate_xml_dir(datapath)
 
-      tmpfile_name = Pathname(Dir.tmpdir) + 'entries.json.tmp'
-      targetfile   = if letter.nil?
-                       datapath + 'entries.json.gz'
-                     else
-                       datapath + "entries_#{letter}.json.gz"
-                     end
-      outfile      = Zlib::GzipWriter.open(tmpfile_name)
+      entries_tmpfile_name = Pathname(Dir.tmpdir) + 'entries.json.tmp'
+      quotes_tmpfile_name  = Pathname(Dir.tmpdir) + 'quotes.json.tmp'
 
-      logger.info "Targeting #{targetfile}"
+      logger.info "letter is #{letter}"
+      if letter.nil?
+        entries_targetfile = datapath + 'entries.json.gz'
+        quotes_targetfile  = datapath + 'quotes.json.gz'
+      else
+        entries_targetfile = datapath + "entries_#{letter}.json.gz"
+        quotes_targetfile  = datapath + "quotes_#{letter}.json.gz"
+      end
+
+      entries_outfile = Zlib::GzipWriter.open(entries_tmpfile_name)
+      quotes_outfile  = Zlib::GzipWriter.open(quotes_tmpfile_name)
+
+      logger.info "Targeting #{entries_targetfile}"
+
       oedfile = find_oed_file(datapath)
       logger.info "Loading OED links from #{oedfile} so we can push them into entries"
       oed = MiddleEnglishDictionary::Collection::OEDLinkSet.from_xml_file(oedfile)
+
+      doefile = find_doe_file(datapath)
+      logger.info "Loading DOE links from #{doefile} so we can push them into entries, too"
+      doe = MiddleEnglishDictionary::Collection::DOELinkSet.from_xml_file(doefile)
 
       count             = 0
       current_directory = ''
       Dir.glob("#{datapath}/xml/#{letter}*/MED*xml").each do |filename|
         count += 1
         logger.info "#{count} done" if count > 0 and count % 2500 == 0
+        if File.empty?(filename)
+          logger.error "File '#{filename}' is empty"
+          next
+        end
         current_directory = get_and_log_directory(filename, current_directory)
 
-        entry = create_and_fill_entry(xmlfilepath: filename, oedlinks: oed)
-        outfile.puts entry.to_json
+        entry = create_and_fill_entry(xmlfilepath: filename, oedlinks: oed, doelinks: doe)
+        begin
+          entries_outfile.puts entry.to_json
+          entry.all_citations.each do |cite|
+            quotes_outfile.puts Dromedary::IndexableQuote.new(citation: cite).to_json
+          end
+        rescue => e
+          require 'pry'; binding.pry
+        end
       end
       logger.info "Finished converting #{count} entries."
 
-      outfile.close
+      #close the zipfiles
+      entries_outfile.close
+      quotes_outfile.close
 
-      logger.info "Copying temporary file to real location in #{datapath}"
+
+      logger.info "Copying temporary files to real location at '#{datapath}'"
 
       # Copy the tempfile over if we made it this far
-      FileUtils.cp(tmpfile_name, targetfile)
+      FileUtils.cp(entries_tmpfile_name, entries_targetfile)
+      FileUtils.cp(quotes_tmpfile_name, quotes_targetfile)
     end
 
 
     private
 
 
-      def get_and_log_directory(filename, current_directory)
-        m       = DIR_NAME_REGEX.match(filename)
-        dirname = m[1]
+    def get_and_log_directory(filename, current_directory)
+      m       = DIR_NAME_REGEX.match(filename)
+      dirname = m[1]
 
-        if dirname != current_directory
-          logger.info "Starting on #{dirname}"
-          dirname
-        else
-          current_directory
-        end
+      if dirname != current_directory
+        logger.info "Starting on #{dirname}"
+        dirname
+      else
+        current_directory
       end
+    end
 
 
-      # @param [Pathname] xmlfilepath Path to the xml file being processed
-      # @param [MiddleEnglishDictionary::Collection::OEDLinkSet] oedlinks
-      # @return MiddleEnglishDictionary::Entry
-      def create_and_fill_entry(xmlfilepath:, oedlinks:)
-        entry         = MiddleEnglishDictionary::Entry.new_from_xml_file(xmlfilepath)
-        entry.oedlink = oedlinks[entry.id]
-        entry
-      rescue MiddleEnglishDictionary::FileNotFound,
-          MiddleEnglishDictionary::FileEmpty,
-          MiddleEnglishDictionary::InvalidXML => e
-        logger.error e.message
-      rescue => e
-        puts e
-        require 'pry'; binding.pry
+    # @param [Pathname] xmlfilepath Path to the xml file being processed
+    # @param [MiddleEnglishDictionary::Collection::OEDLinkSet] oedlinks
+    # @return MiddleEnglishDictionary::Entry
+    def create_and_fill_entry(xmlfilepath:, oedlinks:, doelinks:)
+      entry          = MiddleEnglishDictionary::Entry.new_from_xml_file(xmlfilepath)
+      entry.oedlinks = oedlinks[entry.id]
+      entry.doelinks = doelinks[entry.id]
+      entry
+    rescue MiddleEnglishDictionary::FileNotFound,
+      MiddleEnglishDictionary::FileEmpty,
+      MiddleEnglishDictionary::InvalidXML => e
+      logger.error e.message
+    rescue => e
+      puts e
+      require 'pry'; binding.pry
+      puts "Error in #{entry.source}"
+    end
 
-        puts "Error in #{entry.source}"
+
+    def start_new_letter(datapath, this_letter)
+      logger.info "Beginning work on words starting with #{this_letter}"
+      jdir = (datapath + 'json' + this_letter).to_s
+      FileUtils.mkpath(jdir) unless File.exists? jdir
+    end
+
+
+    def letter_and_filename(f)
+      m           = %r(xml/((.*?)/(.*))\.xml\Z).match(f)
+      this_letter = m[2]
+      this_file   = m[1]
+      return this_file, this_letter
+    end
+
+
+    def validate_xml_dir(datapath)
+      if Dir.exist?(datapath) and Dir.exist?(datapath + 'xml')
+        logger.info "Found xml directory at #{datapath + 'xml'}"
+      else
+        raise "Can't find xml directory at #{datapath + 'xml'}. Exiting"
       end
-
-
-      def start_new_letter(datapath, this_letter)
-        logger.info "Beginning work on words starting with #{this_letter}"
-        jdir = (datapath + 'json' + this_letter).to_s
-        FileUtils.mkpath(jdir) unless File.exists? jdir
-      end
-
-
-      def letter_and_filename(f)
-        m           = %r(xml/((.*?)/(.*))\.xml\Z).match(f)
-        this_letter = m[2]
-        this_file   = m[1]
-        return this_file, this_letter
-      end
-
-
-      def validate_xml_dir(datapath)
-        if Dir.exist?(datapath) and Dir.exist?(datapath + 'xml')
-          logger.info "Found xml directory at #{datapath + 'xml'}"
-        else
-          raise "Can't find xml directory at #{datapath + 'xml'}. Exiting"
-        end
-      end
+    end
   end
 end

--- a/lib/med_installer/index.rb
+++ b/lib/med_installer/index.rb
@@ -16,16 +16,21 @@ module MedInstaller
       desc "Index entries into solr using the traject configuration in indexer/main_indexer.rb"
 
       argument :filename, required: true, desc: "The location of entries.json"
-
+      option :debug, type: :boolean, default: false, desc: "Write to debug file"
       INDEX_DIR = AnnoyingUtilities::DROMEDARY_ROOT + 'indexer'
 
-      def call(filename:)
+      def call(filename:, debug:)
         raise "Solr at #{AnnoyingUtilities.solr_url} not up" unless AnnoyingUtilities.solr_core.up?
 
         index_dir = AnnoyingUtilities::DROMEDARY_ROOT + 'indexer'
 
-        writer = index_dir + 'writers' + 'localhost.rb'
-        fields = index_dir + 'entry_indexer.rb'
+        writer = if debug
+                   index_dir  + 'writers' + 'debug.rb'
+                 else
+                   index_dir + 'writers' + 'localhost.rb'
+                 end
+
+        fields = index_dir + 'main_indexing_rules.rb'
 
         system "bundle", "exec", "traject",
                "-c", fields.to_s,

--- a/lib/med_installer/indexer/entry_json_reader.rb
+++ b/lib/med_installer/indexer/entry_json_reader.rb
@@ -37,6 +37,9 @@ module MedInstaller
     DATAFILEKEY = 'med.data_file'
 
 
+
+    attr_accessor :oed_set, :doe_set
+
     def initialize(settings)
       @data_file = get_data_file(settings)
     end
@@ -47,6 +50,7 @@ module MedInstaller
           entry = MiddleEnglishDictionary::Entry.from_json(json_line)
           yield entry
         rescue => e
+          require 'pry'; binding.pry
           logger.error "Error with json line #{index}: #{e}\n#{e.backtrace}"
         end
       end

--- a/lib/serialization/indexable_quote.rb
+++ b/lib/serialization/indexable_quote.rb
@@ -1,0 +1,68 @@
+require 'annoying_utilities'
+require 'middle_english_dictionary'
+
+module Dromedary
+  # For quotes, a record is a simple structure
+  #   quote: <string>
+  #   entry_id: "MED..."
+  #   cd: date_of_creation.to_i,
+  #   md: date_of_manuscript.to_i
+  #   date: the actual date string
+  #   quote_html: html of the quote <string>,
+  #   rid: rid for this stencil
+  #   title: title of the stencil
+  #   manuscript_abbrev: manuscript abbreviation thing
+  #   scope: the "scope" (page number-lik things)
+  class IndexableQuote
+
+    XSLT = Nokogiri::XSLT(File.read(AnnoyingUtilities::DROMEDARY_ROOT + 'indexer' + 'xslt' + 'Common.xsl'))
+
+    attr_accessor :quote, :entry_id, :cd, :md, :quote_html, :date,
+                  :scope, :rid, :title, :ms,
+                  :citation
+
+    alias_method :med_id, :entry_id
+
+    def initialize(citation: citation)
+      self.quote      = citation.quote.text
+      self.entry_id   = citation.entry_id
+      self.cd         = citation.cd
+      self.md         = citation.md
+      quote_node = Nokogiri::XML(citation.quote.xml)
+      self.quote_html = XSLT.transform(quote_node).to_html.chomp
+      self.scope      = citation.bib.scope
+
+      stencil       = citation.bib.stencil
+      self.rid      = stencil.rid
+      self.date     = stencil.date
+      self.title    = stencil.title
+      self.ms       = stencil.ms
+      self.citation = citation
+    end
+
+    # Provide a JSON representation of this object and all its sub-objects
+    # @return [String] json for this object
+    def to_json
+      IndexableQuoteRepresenter.new(self).to_json
+    end
+
+  end
+
+  class IndexableQuoteRepresenter < Representable::Decorator
+    include Representable::JSON
+
+    property :quote
+    property :entry_id
+    property :cd
+    property :md
+    property :quote_html
+    property :scope
+    property :rid
+    property :date
+    property :title
+    property :ms
+    property :citation, decorator: MiddleEnglishDictionary::Entry::CitationRepresenter, class: MiddleEnglishDictionary::Entry::Citation
+  end
+
+
+end

--- a/solr/med/conf/schema.xml
+++ b/solr/med/conf/schema.xml
@@ -199,8 +199,7 @@
   <field name="orth"         type="me_text" indexed="true" stored="true" multiValued="true"/>
 
   <!--Etymology and Part of speach-->
-  <field name="pos_raw"        type="string"  stored="true" indexed="true" multiValued="false" docValues="true"/>
-  <field name="pos_abbrev" type="string"  stored="true" indexed="true" multiValued="false" docValues="true"/>
+  <field name="pos"        type="string"  stored="true" indexed="true" multiValued="true" docValues="true"/>
   <field name="etyma_language" type="string" indexed="true" stored="true" multiValued="true"/>
   <field name="etyma_text" type="text" indexed="true" stored="true" multiValued="true"/>
 
@@ -212,31 +211,41 @@
   <!-- Notes -->
   <field name="notes" type="text" indexed="true" stored="true" multiValued="true"/>
 
+  <!-- Quotes -->
   <field name="quote_text"  type="me_text" indexed="true" stored="true" multiValued="true"/>
   <field name="quote_title" type="me_text" indexed="true" stored="true" multiValued="true"/>
   <field name="quote_manuscript" type="text" indexed="true" stored="true" multiValued="true"/>
-  <field name="quote_rid" type="me_text" indexed="true" stored="true" multiValued="true"/>
-  <field name="quote_md" type="int" indexed="true" stored="true" multiValued="true"/>
-  <field name="quote_cd" type="int" indexed="true" stored="true" multiValued="true"/>
+  <field name="quote_date" type="string" indexed="false" stored="true" multiValued="true"/>
+  <field name="rid" type="string" indexed="true" stored="true" multiValued="true"/>
+  <field name="md" type="int" indexed="true" stored="true" multiValued="true"/>
+  <field name="cd" type="int" indexed="true" stored="true" multiValued="true"/>
+
 
   <!-- Usage -->
   <field name="discipline_usage" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
 
 
-
   <!-- ######################################################################
-                     Source for Suggestion Handlers
+            Specific to the quote document type
        ###################################################################### -->
 
-  <field name="word_suggestions" type="me_text" indexed="true" stored="true" multiValued="true"/>
+  <field name="entry_id" type="string" indexed="true" stored="true" multiValued="false"/>
+  <field name="citation_json" type="string" indexed="false" stored="true" multiValued="false"/>
+  <field name="quote_html" type="string" indexed="false" stored="true" multiValued="false"/>
+  <field name="scope" type="text" indexed="true" multiValued="false"/>
 
-  <field name="headword_only_suggestions" type="me_text" indexed="true" stored="true" multiValued="true"/>
+<!-- ######################################################################
+                   Source for Suggestion Handlers
+     ###################################################################### -->
+
+<field name="word_suggestions" type="me_text" indexed="true" stored="true" multiValued="true"/>
+<field name="headword_only_suggestions" type="me_text" indexed="true" stored="true" multiValued="true"/>
 
 
 
-  <!-- Field to use to determine and enforce document uniqueness.
-     Unless this field is marked with required="false", it will be a required field
-  -->
+<!-- Field to use to determine and enforce document uniqueness.
+   Unless this field is marked with required="false", it will be a required field
+-->
   <uniqueKey>id</uniqueKey>
 
 


### PR DESCRIPTION
Huge, over-large, way-too-big commit that touches too many things.

The main change here is the creation and indexing of quotation objects being injected into the general indexing scheme. These are predicated on changes in the middle_english_dictionary, reflected in the Gemfile as now requiring v. 1.1.0 of that gem.

Muddied in with all of that is new access to OED/DOE links.  
See middle_english_dictionary gem for oed/doelink
access, esp. https://github.com/mlibrary/middle_english_dictionary/pull/5

Also use new conversion/indexing in application and change enough of
the oed/doe templates to not break.

Also:

* Added ./serialization/indexable_quote to lib
* Reorganized ./indexing directory