### PR TITLE
MEC-129 Fix routes to allow ids with dot

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,11 @@ Rails.application.routes.draw do
 
   mount Blacklight::Engine => '/'
 
+  # Rails doesn't allow dots in matched ids by default, because reasons.
+  # Override the id matcher with an explicit constraint.
+  match 'catalog/(:id)/track' => 'catalog#show',
+        :constraints => { :id => /[\p{Alnum}\-\.]+/ }, via: [:get, :post]
+
   root to: "catalog#home"
   
   concern :searchable, Blacklight::Routes::Searchable.new


### PR DESCRIPTION
Rails default is to disallow ids with a dot in them "because the dot is used as a separator for formatted routes". Add an explicit constraint to a route so it works with MED1234.5.