### PR TITLE
Add citation conversion, indexing, and search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 # When developing in tandem, a relative path is nice and easy
 
 # gem 'middle_english_dictionary', path: "/Users/dueberb/devel/med/middle_english_dictionary"
-gem 'middle_english_dictionary', '=1.1.0'
+gem 'middle_english_dictionary', '=1.2.0'
 
 
 # Rails and blacklight and such

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
     marc-fastxmlwriter (1.0.0)
       marc (~> 1.0)
     method_source (0.9.0)
-    middle_english_dictionary (1.1.0)
+    middle_english_dictionary (1.2.0)
       multi_json
       nokogiri (~> 1.6)
       representable
@@ -338,7 +338,7 @@ DEPENDENCIES
   jquery-rails
   listen
   mail_form (= 1.7.0)
-  middle_english_dictionary (= 1.1.0)
+  middle_english_dictionary (= 1.2.0)
   mysql2 (< 0.5.0)
   nestive (= 0.6.0)
   nokogiri

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -194,55 +194,71 @@ class CatalogController < ApplicationController
 
     config.add_search_field("hnf", label: "Headwords and Forms") do |field|
       field.qt                    = "/search"
+      field.solr_parameters       = {:fq => 'type:entry'}
       field.solr_local_parameters = {
         qf: '$headword_and_forms_qf',
-        pf: '$headword_and_forms_pf'
+        pf: '$headword_and_forms_pf',
       }
     end
 
     # Just the headwords
     config.add_search_field("h", label: "Headwords only") do |field|
-      field.qt = '/search'
+      field.qt                    = '/search'
+      field.solr_parameters       = {:fq => 'type:entry'}
       field.solr_local_parameters = {
         qf: '$headword_only_qf',
-        pf: '$headword_only_pf'
+        pf: '$headword_only_pf',
       }
     end
 
     # Anywhere
     config.add_search_field("anywhere", label: "Anywhere") do |field|
-      field.qt = '/search'
+      field.qt                    = '/search'
+      field.solr_parameters       = {:fq => 'type:entry'}
       field.solr_local_parameters = {
-          qf: '$everything_qf',
-          pf: '$everything_pf'
+        qf: '$everything_qf',
+        pf: '$everything_pf',
       }
     end
 
     # OED Modern English equivalent(ish)
     config.add_search_field("oed", label: "Modern English") do |field|
-      field.qt = '/search'
+      field.qt                    = '/search'
+      field.solr_parameters       = {:fq => 'type:entry'}
       field.solr_local_parameters = {
         qf: 'oed_norm',
-        pf: 'oed_norm'
+        pf: 'oed_norm',
       }
     end
 
     # Etymology (why???)
     config.add_search_field('etyma', label: "Etymology") do |field|
-      field.qt = '/search',
+      field.qt                    = '/search'
+      field.solr_parameters       = {:fq => 'type:entry'}
       field.solr_local_parameters = {
-          qf: "etyma_text",
-          pf: "etyma_text"
+        qf: "etyma_text",
+        pf: "etyma_text",
       }
     end
 
     # Notes and definition (all the modern english, basically)
     config.add_search_field('notes_and_def', label: "Definition and Notes") do |field|
-      field.qt = '/search',
-          field.solr_local_parameters = {
-              qf: "definition_text^50 notes",
-              pf: "definition_text^50 notes"
-          }
+      field.qt                    = '/search'
+      field.solr_parameters       = {:fq => 'type:entry'}
+      field.solr_local_parameters = {
+        qf: "definition_text^50 notes",
+        pf: "definition_text^50 notes",
+      }
+    end
+
+    # Citation search
+    config.add_search_field("citation", label: "Citations") do |field|
+      field.qt                    = '/search'
+      field.solr_parameters       = {:fq => 'type:entry'}
+      field.solr_local_parameters = {
+        qf: '$citation_qf',
+        pf: '$citation_pf'
+      }
     end
 
     # Now we see how to over-ride Solr request handler defaults, in this

--- a/indexer/main_indexing_rules.rb
+++ b/indexer/main_indexing_rules.rb
@@ -1,5 +1,3 @@
-
-
 $LOAD_PATH.unshift Pathname.new(__dir__).to_s
 $LOAD_PATH.unshift (Pathname.new(__dir__).parent + 'lib').to_s
 require 'annoying_utilities'
@@ -19,7 +17,7 @@ end
 # Do a terrible disservice to traject and monkeypatch it to take
 # our existing logger
 
-Traject::Indexer.send(:define_method, :logger, ->() {AnnoyingUtilities.logger })
+Traject::Indexer.send(:define_method, :logger, ->() {AnnoyingUtilities.logger})
 
 
 def entry_method(name)
@@ -77,6 +75,14 @@ to_field('doe_norm') do |entry, acc|
   acc << entry.doelinks.normalized_term if entry.doelinks
 end
 
+# Citations
+
+to_field('citation_text') do |entry, acc|
+  entry.all_citations.each do |c|
+    acc << c.text
+  end
+end
+
 # Quotes
 to_field('quote_text') do |entry, acc|
   acc.replace entry.all_quotes.map(&:text)
@@ -96,6 +102,13 @@ to_field('cd') do |entry, acc|
   acc.replace entry.all_citations.flat_map(&:cd).uniq.compact
 end
 
+to_field('min_md') do |entry, acc|
+  acc << entry.all_citations.flat_map(&:md).compact.min
+end
+
+to_field('min_cd') do |entry, acc|
+  acc << entry.all_citations.flat_map(&:cd).compact.min
+end
 
 # Notes
 to_field 'notes', entry_method(:notes)

--- a/indexer/writers/localhost.rb
+++ b/indexer/writers/localhost.rb
@@ -6,7 +6,7 @@ require 'annoying_utilities'
 
 settings do
   provide "solr.url", AnnoyingUtilities.solr_url
-  provide "solr_writer.commit_on_close", "true"
+  provide "solr_writer.commit_on_close", "false"
   provide "solr_writer.thread_pool", 2
   provide "solr_writer.batch_size", 200
   provide "writer_class_name", "Traject::SolrJsonWriter"

--- a/lib/med_installer/index.rb
+++ b/lib/med_installer/index.rb
@@ -41,6 +41,20 @@ module MedInstaller
 
         puts $?.exitstatus
 
+
+        logger.info "Completed indexing. Sending commit and rebuilding autocompletes (long!)"
+
+        core = AnnoyingUtilities.solr_core
+
+        # Commit with index building can take a looooong time. Set the timeout to 100seconds
+        core.rawclient.receive_timeout = 200_000 # 200 seconds
+        core.commit
+
+        logger.info "Optimizing solr index. Even longer!"
+        core.optimize
+
+        logger.info "Process complete"
+
       end
     end
 

--- a/solr/med/conf/schema.xml
+++ b/solr/med/conf/schema.xml
@@ -211,14 +211,22 @@
   <!-- Notes -->
   <field name="notes" type="text" indexed="true" stored="true" multiValued="true"/>
 
+  <!-- Full citation text, including quotes, but not in me_text -->
+
+  <field name="citation_text" type="text" indexed="true" stored="true" multiValued="true"/>
+
   <!-- Quotes -->
   <field name="quote_text"  type="me_text" indexed="true" stored="true" multiValued="true"/>
   <field name="quote_title" type="me_text" indexed="true" stored="true" multiValued="true"/>
   <field name="quote_manuscript" type="text" indexed="true" stored="true" multiValued="true"/>
   <field name="quote_date" type="string" indexed="false" stored="true" multiValued="true"/>
   <field name="rid" type="string" indexed="true" stored="true" multiValued="true"/>
+
+  <!--Dates-->
   <field name="md" type="int" indexed="true" stored="true" multiValued="true"/>
   <field name="cd" type="int" indexed="true" stored="true" multiValued="true"/>
+  <field name="min_md" type="int" indexed="true" stored="true" multiValued="true"/>
+  <field name="min_cd" type="int" indexed="true" stored="true" multiValued="true"/>
 
 
   <!-- Usage -->

--- a/solr/med/conf/solrconfig.xml
+++ b/solr/med/conf/solrconfig.xml
@@ -6,7 +6,10 @@
         <!ENTITY headword_only_search   SYSTEM "solrconfig_med/headword_only_search.xml">
         <!ENTITY headword_and_forms_search   SYSTEM "solrconfig_med/headword_and_forms_search.xml">
         <!ENTITY everything_search   SYSTEM "solrconfig_med/everything_search.xml">
+        <!ENTITY citation_search SYSTEM "solrconfig_med/citation_search.xml">
+
         <!ENTITY highlighting_defaults   SYSTEM "solrconfig_med/highlighting.xml">
+
         <!ENTITY headword_only_suggester SYSTEM "solrconfig_med/suggesters/headword_only_suggester.xml">
         <!ENTITY headword_and_forms_suggester SYSTEM "solrconfig_med/suggesters/headword_and_forms_suggester.xml">
         <!ENTITY oed_suggester SYSTEM "solrconfig_med/suggesters/oed_suggester.xml">
@@ -53,6 +56,7 @@
       &headword_only_search;
       &everything_search;
       &highlighting_defaults;
+      &citation_search;
 
 
 

--- a/solr/med/conf/solrconfig_med/citation_search.xml
+++ b/solr/med/conf/solrconfig_med/citation_search.xml
@@ -1,0 +1,9 @@
+<str name="citation_qf">
+  quote_text^10
+  citation_text
+</str>
+
+<str name="citation_pf">
+  quote_text^10
+  citation_text
+</str>

--- a/solr/med/conf/solrconfig_med/suggesters/doe_suggester.xml
+++ b/solr/med/conf/solrconfig_med/suggesters/doe_suggester.xml
@@ -6,7 +6,7 @@
   <str name="buildOnCommit">true</str>
   <str name="field">doe_norm</str>
   <str name="exactMatchFirst">true</str>
-  <str name="buildOnStartup">true</str>
+  <str name="buildOnStartup">false</str>
   <str name="minPrefixChars">2</str>
   <str name="dictionaryImpl">DocumentDictionaryFactory</str>
   <str name="buildOnCommit">true</str>

--- a/solr/med/conf/solrconfig_med/suggesters/headword_and_forms_suggester.xml
+++ b/solr/med/conf/solrconfig_med/suggesters/headword_and_forms_suggester.xml
@@ -7,7 +7,7 @@
     <str name="buildOnCommit">true</str>
     <str name="field">word_suggestions</str>
     <str name="exactMatchFirst">true</str>
-    <str name="buildOnStartup">true</str>
+    <str name="buildOnStartup">false</str>
     <str name="minPrefixChars">2</str>
     <str name="dictionaryImpl">DocumentDictionaryFactory</str>
     <str name="buildOnCommit">true</str>

--- a/solr/med/conf/solrconfig_med/suggesters/headword_only_suggester.xml
+++ b/solr/med/conf/solrconfig_med/suggesters/headword_only_suggester.xml
@@ -7,7 +7,7 @@
     <str name="buildOnCommit">true</str>
     <str name="field">headword_only_suggestions</str>
     <str name="exactMatchFirst">true</str>
-    <str name="buildOnStartup">true</str>
+    <str name="buildOnStartup">false</str>
     <str name="minPrefixChars">2</str>
     <str name="dictionaryImpl">DocumentDictionaryFactory</str>
     <str name="buildOnCommit">true</str>

--- a/solr/med/conf/solrconfig_med/suggesters/oed_suggester.xml
+++ b/solr/med/conf/solrconfig_med/suggesters/oed_suggester.xml
@@ -6,7 +6,7 @@
   <str name="buildOnCommit">true</str>
   <str name="field">oed_norm</str>
   <str name="exactMatchFirst">true</str>
-  <str name="buildOnStartup">true</str>
+  <str name="buildOnStartup">false</str>
   <str name="minPrefixChars">2</str>
   <str name="dictionaryImpl">DocumentDictionaryFactory</str>
   <str name="buildOnCommit">true</str>


### PR DESCRIPTION
Collect citation text via an update to `middle_english_dicitonary`
and index it, then expose it via a new search type.

Other changes:

  * Update Gemfile to call med gem 1.2
  * Allow a long timeout when building autocomplete indexes
  * Add optimization after commit when indexing
  * Change existing searches to restrict results to
    only entries (via `fq: 'type:entry'`)
