### PR TITLE
Use XSL for display

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 # When developing in tandem, a relative path is nice and easy
 
 # gem 'middle_english_dictionary', path: "/Users/dueberb/devel/med/middle_english_dictionary"
-gem 'middle_english_dictionary', '=1.1.0'
+gem 'middle_english_dictionary', '=1.2.0'
 
 
 # Rails and blacklight and such

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
     marc-fastxmlwriter (1.0.0)
       marc (~> 1.0)
     method_source (0.9.0)
-    middle_english_dictionary (1.1.0)
+    middle_english_dictionary (1.2.0)
       multi_json
       nokogiri (~> 1.6)
       representable
@@ -338,7 +338,7 @@ DEPENDENCIES
   jquery-rails
   listen
   mail_form (= 1.7.0)
-  middle_english_dictionary (= 1.1.0)
+  middle_english_dictionary (= 1.2.0)
   mysql2 (< 0.5.0)
   nestive (= 0.6.0)
   nokogiri

--- a/app/assets/stylesheets/dromedary.scss
+++ b/app/assets/stylesheets/dromedary.scss
@@ -17,11 +17,17 @@
   .entry-heading {
     .entry-headword {
       float: left; font-weight: bold;
+
+      .entry-pos {
+       font-weight: normal;
+       font-style: italic;
+      }
     }
 
-    .quotations-header-options {
+      .quotations-header-options {
         float: right;
-    }
+      }
+
   }
 
   // Several entry page titles
@@ -43,6 +49,11 @@
     font-style: italic;
   }
 
+}
+
+.entry-info {
+    .HDORTH { font-weight: bold }
+    .ORTH { font-style: italic}
 }
 
 // TWO LEVEL MENUS
@@ -87,7 +98,7 @@
     text-align: center;
     text-decoration: underline;
     font-weight: bold;*/
-    
+
 }
 
 .skip-filter-link:focus, .skip_filter_link:active {
@@ -181,7 +192,7 @@
   .para {
     font-size: 20px;
     line-height: 1.6;
-    color: #333333;  
+    color: #333333;
   }
 
   p.help-block {
@@ -244,7 +255,7 @@ body.blacklight-static,
 body.blacklight-contacts-new,
 body.blacklight-contacts-create {
   background-color: #f2f2f2;
-  color: #6e6e6e;    
+  color: #6e6e6e;
   line-height: 1.6;
 
   > .container {

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -194,55 +194,71 @@ class CatalogController < ApplicationController
 
     config.add_search_field("hnf", label: "Headwords and Forms") do |field|
       field.qt                    = "/search"
+      field.solr_parameters       = {:fq => 'type:entry'}
       field.solr_local_parameters = {
         qf: '$headword_and_forms_qf',
-        pf: '$headword_and_forms_pf'
+        pf: '$headword_and_forms_pf',
       }
     end
 
     # Just the headwords
     config.add_search_field("h", label: "Headwords only") do |field|
-      field.qt = '/search'
+      field.qt                    = '/search'
+      field.solr_parameters       = {:fq => 'type:entry'}
       field.solr_local_parameters = {
         qf: '$headword_only_qf',
-        pf: '$headword_only_pf'
+        pf: '$headword_only_pf',
       }
     end
 
     # Anywhere
     config.add_search_field("anywhere", label: "Anywhere") do |field|
-      field.qt = '/search'
+      field.qt                    = '/search'
+      field.solr_parameters       = {:fq => 'type:entry'}
       field.solr_local_parameters = {
-          qf: '$everything_qf',
-          pf: '$everything_pf'
+        qf: '$everything_qf',
+        pf: '$everything_pf',
       }
     end
 
     # OED Modern English equivalent(ish)
     config.add_search_field("oed", label: "Modern English") do |field|
-      field.qt = '/search'
+      field.qt                    = '/search'
+      field.solr_parameters       = {:fq => 'type:entry'}
       field.solr_local_parameters = {
         qf: 'oed_norm',
-        pf: 'oed_norm'
+        pf: 'oed_norm',
       }
     end
 
     # Etymology (why???)
     config.add_search_field('etyma', label: "Etymology") do |field|
-      field.qt = '/search',
+      field.qt                    = '/search'
+      field.solr_parameters       = {:fq => 'type:entry'}
       field.solr_local_parameters = {
-          qf: "etyma_text",
-          pf: "etyma_text"
+        qf: "etyma_text",
+        pf: "etyma_text",
       }
     end
 
     # Notes and definition (all the modern english, basically)
     config.add_search_field('notes_and_def', label: "Definition and Notes") do |field|
-      field.qt = '/search',
-          field.solr_local_parameters = {
-              qf: "definition_text^50 notes",
-              pf: "definition_text^50 notes"
-          }
+      field.qt                    = '/search'
+      field.solr_parameters       = {:fq => 'type:entry'}
+      field.solr_local_parameters = {
+        qf: "definition_text^50 notes",
+        pf: "definition_text^50 notes",
+      }
+    end
+
+    # Citation search
+    config.add_search_field("citation", label: "Citations") do |field|
+      field.qt                    = '/search'
+      field.solr_parameters       = {:fq => 'type:entry'}
+      field.solr_local_parameters = {
+        qf: '$citation_qf',
+        pf: '$citation_pf'
+      }
     end
 
     # Now we see how to over-ride Solr request handler defaults, in this

--- a/app/helpers/med_quotes_helper.rb
+++ b/app/helpers/med_quotes_helper.rb
@@ -1,6 +1,6 @@
 module MedQuotesHelper
 
-	  def med_quotes_help(sense)
+	  def med_quotes_help(sense, doc_presenter)
       quotes = {}
       quote_count = 0
       egs = sense.egs
@@ -11,13 +11,13 @@ module MedQuotesHelper
           subdef_arr = []
           citations.each do |cite|
             sten = cite.bib.stencil
-            sten_date = get_quote_value(sten.date)
-            sten_title = get_quote_value(sten.title)
-            sten_title  = '<span class="cite_bib_stencil_title">' + sten_title  + '</span>'
-            sten_ms = get_quote_value(sten.ms)
+            # sten_date = get_quote_value(sten.date)
+            # sten_title = get_quote_value(sten.title)
+            # sten_title  = '<span class="cite_bib_stencil_title">' + sten_title  + '</span>'
+            # sten_ms = get_quote_value(sten.ms)
             sten_rid =  get_quote_value(sten.rid)
-            cite_bib_scope = get_quote_value(cite.bib.scope)
-            cite_quote_text =  get_quote_value(cite.quote.text)
+            # cite_bib_scope = get_quote_value(cite.bib.scope)
+            # cite_quote_text =  get_quote_value(cite.quote.text)
             cite_link = "https://quod.lib.umich.edu/cgi/m/mec/hyp-idx?type=id&id=#{sten_rid}"
 
             # Rails.logger.debug "sten_date: " + sten_date
@@ -28,8 +28,20 @@ module MedQuotesHelper
             # Rails.logger.debug "cite_quote_text: " + cite_quote_text
             # Rails.logger.debug "cite_link: " + cite_link
 
-            quote_str = '<a href="' + cite_link + '" > ' + sten_date + ' ' + sten_title
-            quote_str = quote_str + sten_ms + '</a> ' + cite_bib_scope + ' ' + cite_quote_text
+            # quote_str = '<a href="' + cite_link + '" > ' + sten_date + ' ' + sten_title
+            # quote_str = quote_str + sten_ms + '</a> ' + cite_bib_scope + ' ' + cite_quote_text
+
+            # binding.pry
+
+            
+
+            puts "IN med_quotes_help doc_presenter IS: #{doc_presenter}"
+
+            puts "IN med_quotes_help CITE IS: #{cite}"
+            cite_html = doc_presenter.cit_html(cite)
+            puts "IN med_quotes_help AFTER doc_presenter.cit_html(cite) cite_html IS: #{cite_html}"
+
+            quote_str = '<a href="' + cite_link + '" > ' + cite_html + '</a> '
 
             # Rails.logger.debug "quote_str: " + quote_str
             quote_count += 1

--- a/app/presenters/dromedary/index_presenter.rb
+++ b/app/presenters/dromedary/index_presenter.rb
@@ -31,112 +31,69 @@ module Dromedary
       @search_field = view_context.search_state.params_for_search['search_field']
     end
 
+
     ##### XSLT TRANSFORMS #####
 
-    def form_xslt
-      @form_xsl ||= Nokogiri::XSLT(File.read('./indexer/xslt/FormOnly.xsl'))
+    # Let's load up the XSLT transforms as constants
+    # so we only get them once
+    XSL_DIR = Pathname.new "./indexer/xslt"
+
+
+    def self.load_xslt(basename)
+      Nokogiri::XSLT(File.open(XSL_DIR + basename, 'r:utf-8').read)
     end
 
-    def def_xslt
-      @def_xslt ||= Nokogiri::XSLT(File.read('./indexer/xslt/DefOnly.xsl'))
-    end
 
-    def cit_xslt
-      @cit_xslt ||= Nokogiri::XSLT(File.read('./indexer/xslt/CitOnly.xsl'))
-      puts "IN INDEXPRESENTER @cit_xslt IS: #{@cit_xslt}"
-    end
-
-    def etym_xslt
-      @etym_xslt ||= Nokogiri::XSLT(File.read('./indexer/xslt/EtymOnly.xsl'))
-    end
-
-    def note_xslt
-      @note_xslt ||= Nokogiri::XSLT(File.read('./indexer/xslt/NoteOnly.xsl'))
-    end
-
-    def supplement_xslt
-      @supplement_xslt ||= Nokogiri::XSLT(File.read('./indexer/xslt/SupplementOnly.xsl'))
-    end
-
-    ####### Getting nokogiri nodes #####
-
-    # def entry_node
-    #   @nokonode = Nokogiri::XML(@entry_nokonode)
-    # end
-
-    # @return [Nokogiri::Node | nil] nil if there isn't a FORM section, the node otherwise
-    def form_doc
-      doc_from('/ENTRYFREE/FORM')
-    end
-
-    def doc_from(xpath)
-      node = @nokonode.xpath(xpath)
-      node = node.first
-      return nil if node.nil?
-      doc = Nokogiri::XML::Document.new
-      doc.add_child node.dup
-      doc
-    end
+    FORM_XSLT       = load_xslt('FormOnly.xsl')
+    DEF_XSLT        = load_xslt('DefOnly.xsl')
+    CIT_XSLT        = load_xslt('CitOnly.xsl')
+    ETYM_XSLT       = load_xslt('EtymOnly.xsl')
+    NOTE_XSLT       = load_xslt('NoteOnly.xsl')
+    SUPPLEMENT_XSLT = load_xslt('SupplementOnly.xsl')
 
 
     # There's only one FORM section, so just take care of it here
-    # @return [String] the transformed form
+    # @return [String] the transformed form, or nil
     def form_html
-      return nil unless form_doc
-      form_xslt.apply_to(form_doc)
+      xsl_transform_from_entry('/ENTRYFREE/FORM', FORM_XSLT)
     end
+
 
     # There's only one ETYM section, so just take care of it here
-    # @return [String] the transformed form
-    def etym_doc
-      doc_from('/ENTRYFREE/ETYM')
+    # @return [String] the transformed etym, or nil
+    def etym_html
+      xsl_transform_from_entry('/ENTRYFREE/ETYM', ETYM_XSLT)
     end
 
-    def etym_html
-      return nil unless etym_doc
-      etym_xslt.apply_to(etym_doc)
-    end  
 
     # @param [MiddleEnglishDictionary::Entry::Sense] sense The sense whose def you want
-    # @return [String] The definition transformed into HTML
+    # @return [String, nil] The definition transformed into HTML, or nil
     def def_html(sense)
-      return nil unless sense.definition_xml
-      nokonode = Nokogiri::XML(sense.definition_xml)
-      def_xslt.apply_to(nokonode)
+      xsl_transform_from_xml(sense.definition_xml, DEF_XSLT)
     end
 
+
+    # @param [MiddleEnglishDictionary::Entry::Note] note The note object
+    # @return [String, nil] The note transformed into HTML, or nil
     def note_html(note)
-      return nil unless note.xml
-      nokonode = Nokogiri::XML(note.xml)
-      note_xslt.apply_to(nokonode)
+      xsl_transform_from_xml(note.xml, NOTE_XSLT)
     end
 
+    # @param [MiddleEnglishDictionary::Entry::Citation] cit The citation object
+    # @return [String, nil] The citatation transformed into HTML, or nil
     def cit_html(cit)
-      sten = cit.bib.stencil
-      x = sten.instance_variable_get(:@xml)
-      puts "IN CIT_HTML cit is #{cit}"
-      puts "IN CIT_HTML sten is #{sten}"
-      puts "IN CIT_HTML sten.xml is #{x}"
-      return nil unless x
-      # nokonode = Nokogiri::XML(x)
-      cit_doc = doc_from(x)
-      puts "IN CIT_HTML cit_doc is #{cit_doc}"
-      cit_doc
-
-      # html = cit_xslt.apply_to(nokonode)
-      # puts "IN CIT_HTML html is #{html}"
-      # html
+      xsl_transform_from_xml(cit.xml, CIT_XSLT)
     end
 
-    def supplement_node(supplement)
-      Nokogiri::XML(supplement.xml)
-    end
+    alias_method :cite_html, :cit_html
+    alias_method :citation_html, :cit_html
 
+    # @param [MiddleEnglishDictionary::Entry::Supplement] supplement The supplement object
+    # @return [String, nil] The supplement transformed into HTML, or nil
     def supplement_html(supplement)
-      return nil unless supplement.xml
-      nokonode = Nokogiri::XML(supplement.xml)
-      supplement_xslt.apply_to(nokonode)
+      xsl_transform_from_xml(supplement.xml, SUPPLEMENT_XSLT)
     end
+
 
     ####### Ealier Methods #####
 
@@ -145,13 +102,15 @@ module Dromedary
       @entry.pos
     end
 
+
     # @return [Array<MiddleEnglishDictionary::Sense>] All the entry senses
     # modified to replace '~' with regularized headword
     def senses
       headw = @entry.headwords.first.instance_variable_get(:@regs).first
-      @entry.senses.each { |sen| sen.definition_xml.gsub! '~', headw}
+      @entry.senses.each {|sen| sen.definition_xml.gsub! '~', headw}
       @entry.senses
     end
+
 
     # @return [Integer] The number of quotes across all senses
     def quote_count
@@ -165,13 +124,13 @@ module Dromedary
       Array(hl_field('official_headword')).first
     end
 
+
     # @return [Array<String>] The non-headword spellings as taken from the "highlight"
     # section of the solr return (with embedded tags for highlighting)
     def highlighted_other_spellings
-       hl_field('headword').reject{|w| w == highlighted_official_headword}
+      hl_field('headword').reject {|w| w == highlighted_official_headword}
     end
 
-    private
 
     # A convenience method to get the highlighted values for a field if
     # they're available, falling back to the regular document values for
@@ -189,6 +148,66 @@ module Dromedary
       else
         []
       end
+    end
+
+
+    ####### XSLT Transform helpers #####
+
+    # Create a document from the given node, or nil if nil was passed
+    # @param [Nokogiri::XML::Node] node The node to document-ify
+    # @return [Nokgiri::XML::Document] A document containing nothing but that node
+    def doc_from_node(node)
+      return nil if node.nil?
+      return node.dup if node.document?
+      doc = Nokogiri::XML::Document.new
+      doc.add_child node.dup
+      doc
+    end
+
+
+    # We need to pass a full XML document node (not just an element) to
+    # the XSLT transform, so we make one here.
+    #
+    # Given an xpath, find the first corresponding node in the @entry
+    # nokonode and turn it into a free-standing document that contains
+    # only that node
+    # @param [String] xpath The xpath in the @entry nokonode (starting with '/ENTRY')
+    # @return [Nokogiri::XML::Document, nil] The created nokogiri document, or nil if not found
+    def doc_from_xpath(xpath)
+      doc_from_node(@nokonode.xpath(xpath).first)
+    end
+
+
+    # Given a nokogiri node, turn it into a document (if it isn't already)
+    # and apply the provided xslt transformation
+    # @param [String] xpath The xpath into the entry (root is '/ENTRYFREE')
+    # @param [Nokogiri::XSLT] xslt The XSLT object used to do the transformation
+    # @return [String,nil] The transfored text (usualy html), or nil if the xpath not found
+    def xsl_transform_from_node(node, xslt)
+      return nil if node.nil?
+      xslt.apply_to(doc_from_node(node))
+    end
+
+
+    # Given an XML snippet or nil, and an xslt object, return
+    # the transformation (or nil if the snippet was nil)
+    # @param [String,nil] xml The raw XML string, or nil
+    # @param [Nokogiri::XSLT] xslt The XSLT object used to do the transformation
+    # @return [String,nil] The transfored text (usualy html), or nil if the xpath not found
+    def xsl_transform_from_xml(xml, xslt)
+      return nil if xml.nil?
+      xsl_transform_from_node(Nokogiri::XML(xml), xslt)
+    end
+
+    # Given an xpath in the @entry nokonode (sent to #doc_from_xpath) and
+    # an xslt transform (probably from the constants above), return the
+    # transformed-into-html value
+    #
+    # @param [String] xpath The xpath into the entry (root is '/ENTRYFREE')
+    # @param [Nokogiri::XSLT] xslt The XSLT object used to do the transformation
+    # @return [String,nil] The transfored text (usualy html), or nil if the xpath not found
+    def xsl_transform_from_entry(xpath, xslt)
+      xsl_transform_from_node(doc_from_xpath(xpath), xslt)
     end
 
   end

--- a/app/views/catalog/_index_header_entry.html.erb
+++ b/app/views/catalog/_index_header_entry.html.erb
@@ -20,7 +20,7 @@
           </span>
         <% end %>
         <%= link_to_document document, doc_presenter.highlighted_official_headword, counter: counter %>
-        (<%== doc_presenter.part_of_speech_abbrev %>)
+        <span class="POS"><%== doc_presenter.part_of_speech_abbrev %></span>
       </h3>
 
       <div class="search-result def">
@@ -38,14 +38,14 @@
             <tr>
               <% sense = doc_presenter.senses.first %>
               <% unless sense.nil? %>
-              <% def_xml = Nokogiri::XML(sense.definition_xml) %>
-              <% def_xslt = Nokogiri::XSLT(File.read('./indexer/xslt/DefOnly.xsl'))%>
-              <% current_def =  def_xslt.apply_to(def_xml)[0..200] %>
-              <!-- FYI: "\u2026" is an ellipsis -->
-              <td class="index-definition-tag">Sense (Definition)</td>
-              <td class="index-definition"><%== current_def %><span class="ellipsis-link"><%= link_to "\u2026", document %></span></td>
+                <% cdef = doc_presenter.def_html(sense)[0..300] %>
+                <!-- FYI: "\u2026" is an ellipsis -->
+                <td class="index-definition-tag">Sense (Definition)</td>
+                <td class="index-definition"><%== cdef %>
+                  <span class="ellipsis-link"><a href="<%= url_for document%>">&hellip;</a></span></td>
               <% else %>
-                <td></td><td class="missing-def">No definition available</td>
+                <td></td>
+                <td class="missing-def">No definition available</td>
               <% end %>
             </tr>
           </table>

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -4,123 +4,171 @@
 
 <%# default partial to display solr document fields in catalog show view -%>
 <div class="entry-panel">
-  
+
   <%# Display Heading for MED Entry %>
   <h2 class="entry-main-title">Middle English Dictionary Entry</h2>
 
   <%# Get headword and display it with quotes hide/show %>
   <div class="entry-heading">
     <div class="entry-container">
-      <div class="entry-headword"><%= ent.original_headwords.first %>&nbsp;(<span class="entry-pos"><%= ent.pos %>)</span></div>
+      <div class="entry-headword">
+        <%= ent.original_headwords.join(", ") %>&nbsp;<span class="entry-pos"><%= ent.pos %></span>
+      </div>
 
-      <% unless doc_presenter.senses.first.nil? %>
-        <div class="quotations-header-options"><span class="quotations-header-options-text">Quotations:</span> <a href="#" onClick="function show_quotes(){ $( 'tr.quotes' ).show();   } show_quotes(); return false;">Show All</a> <a href="#" onClick="function hide_quotes(){ $( 'tr.quotes' ).hide();  } hide_quotes(); return false;">Hide All</a></div>
+      <% if doc_presenter.senses.size > 0 %>
+        <div class="quotations-header-options">
+          <span class="quotations-header-options-text">Quotations:</span>
+            <a class="show-all-button" href="#" onClick="$('.eg').show(); return false;">Show all</a>
+            <a class="hide-all-button" href="#" onClick="$('.eg').hide();return false">Hide
+            all</a>
+        </div>
       <% end %>
-
     </div>
   </div>
 
-  <%# Get get forms and etymology and display %>
+  <%# Get forms and etymology and display %>
   <div>
-      <h3 class="entry-intro-title">Entry Info</h3>
+    <h3 class="entry-intro-title">Entry Info</h3>
   </div>
 
   <div class="table-responsive entry-info">
     <table class="table table-striped">
-      <tr><td class="forms-title">Forms</td><td class="forms-list">
-        <%# binding.pry %>
-        <%# ent.all_forms.each_with_index do |(k, v)|  %><%#= k %><%#= "," if k != ent.all_forms.last %><%# end %>
+      <tr>
+        <td class="forms-title">Forms</td>
+        <td>
           <%== doc_presenter.form_html %>
-        </td></tr>
-      <tr><td class="etymology-title">Etymology</td><td class="etymology-list">
-          <%# etym_xml = Nokogiri::XML(ent.etym_xml) %>
-          <%# etym_xslt = Nokogiri::XSLT(File.read('./indexer/xslt/EtymOnly.xsl'))%>
-          <%# current_etym = etym_xslt.apply_to(etym_xml) %>
+        </td>
+      </tr>
+      <tr>
+        <td class="etymology-title">Etymology</td>
+        <td class="etymology-list">
           <%== doc_presenter.etym_html %>
-      </td></tr>
+        </td>
+      </tr>
     </table>
   </div>
+
+
+  <!--
+  If we have senses
+    display the heading
+    foreach sense
+      show the definition
+      if we have egs
+        show the collapse/expand link
+        foreach eg
+          display the eg subsense tag (if any)
+          foreach cite
+            display the cite
+
+  One partial for the sense
+    ...with one for an eg
+    ...with one for a cite
+    
+  -->
 
   <%# Get get senses plus their quotes and display %>
-  <% unless doc_presenter.senses.first.nil? %>
-    <h3 class="entry-senses-title">Senses and Subsenses</h3>
+  <% unless doc_presenter.senses.size == 0 %>
+    <div class="senses">
+      <div class="entry-senses-title">Senses and Subsenses</div>
+
+      <% doc_presenter.senses.each_with_index do |sense, index| %>
+          <%= render "catalog/show_entry/sense.html.erb", sense: sense, index: index, presenter: doc_presenter %>
+      <% end %>
+    </div>
+
   <% end %>
 
+
+
+
+
+  <%
+=begin
+ %>
   <div class="table-responsive entry-senses">
     <table class="table">
-        <% doc_presenter.senses.each do |sen|  %>
-            <tr>
-                <td class="senses-index"><%= sen.sense_number.to_s %></td>
-                	<td class="senses-defintion">
-                    <%== doc_presenter.def_html(sen) %>
+      <% doc_presenter.senses.each do |sen| %>
+        <tr>
+          <td class="senses-index"><%= sen.sense_number.to_s %></td>
+          <td class="senses-defintion">
+            <%== doc_presenter.def_html(sen) %>
+          </td>
+          <td class="quotes-control">
+
+            <% jq_sense = "tr.sense_id_" + sen.sense_number.to_s %>
+            <% jq_show_class = "show_" + sen.sense_number.to_s %>
+            <% jq_hide_class = "hide_" + sen.sense_number.to_s %>
+
+            <% quotes, quote_count = med_quotes_help(sen, doc_presenter) %>
+
+
+            <% if !quotes.empty? && quote_count > 0 %>
+              <% quote_show_string = (quote_count == 1) ? "Show Quote" : "Show #{quote_count} " + "Quote".pluralize(quote_count) %>
+
+              <div class="<%= jq_show_class %>">
+                <a href="#" onClick='function show_def_quotes(){ $( "<%= jq_sense %>" ).show(); $(".<%= jq_hide_class %>").show(); $(".<%= jq_show_class %>").hide();
+                    } show_def_quotes(); return false;'><span class="show-hide-label"><%== quote_show_string %></span></a>
+              </div>
+
+              <div class="<%= jq_hide_class %>" style="display:none;">
+                <a href="#" onClick='function hide_def_quotes(){ $("<%= jq_sense %>").hide(); $(".<%= jq_hide_class %>").hide(); $(".<%= jq_show_class %>").show(); } hide_def_quotes(); return false'><span class="show-hide-label"><%== "Hide " + "Quote".pluralize(quote_count) %></span></a>
+              </div>
+            <% end %>
+          </td>
+        </tr>
+
+        <%# class quotes can be used to hide/show all quotes; class q_id_n does the same for individual definition's quotes %>
+        <% if !quotes.empty? && quote_count > 0 %>
+          <% last_subdef_index_index = "" %>
+          <% quotes.each do |subdef_index, q_arr| %>
+            <% q_arr.each do |q| %>
+              <tr class="quotes sense_id_<%= sen.sense_number.to_s %>">
+
+                <td>
+                  <% if subdef_index != last_subdef_index_index %>
+                    <% last_subdef_index_index = subdef_index %>
+                    <span class="subdef-index"><%== subdef_index %>
+                  <% end %>
                 </td>
-                <td  class="quotes-control">
 
-                  <% jq_sense = "tr.sense_id_" + sen.sense_number.to_s  %>
-                  <% jq_show_class = "show_" + sen.sense_number.to_s  %>
-                  <% jq_hide_class = "hide_" + sen.sense_number.to_s  %>
+                <td><%== q %></td>
 
-                  <% quotes, quote_count = med_quotes_help(sen, doc_presenter) %>
-
-
-                  <% if !quotes.empty? && quote_count > 0 %>
-                    <% quote_show_string = (quote_count == 1) ?  "Show Quote" : "Show #{quote_count} " + "Quote".pluralize(quote_count) %>
-
-                    <div class="<%= jq_show_class %>"><a href="#" onClick='function show_def_quotes(){ $( "<%= jq_sense %>" ).show(); $(".<%= jq_hide_class %>").show(); $(".<%= jq_show_class %>").hide(); 
-                       } show_def_quotes(); return false;'><span class="show-hide-label"><%== quote_show_string %></span></a></div>
-
-                    <div class="<%= jq_hide_class %>" style="display:none;"><a href="#" onClick='function hide_def_quotes(){ $("<%= jq_sense %>").hide(); $(".<%= jq_hide_class %>").hide(); $(".<%= jq_show_class %>").show(); } hide_def_quotes(); return false'><span class="show-hide-label"><%== "Hide " + "Quote".pluralize(quote_count) %></span></a>
-                    </div>
-                  <% end %>
-                  </td>
               </tr>
+            <% end %>
+          <% end %>
+        <% end %>
 
-              <%# class quotes can be used to hide/show all quotes; class q_id_n does the same for individual definition's quotes %>
-                <% if !quotes.empty? && quote_count > 0 %>
-                <% last_subdef_index_index = "" %>
-                <% quotes.each do |subdef_index, q_arr| %>
-                  <% q_arr.each do |q| %>
-                    <tr  class="quotes sense_id_<%= sen.sense_number.to_s %>">
-
-                    <td>
-                      <% if subdef_index != last_subdef_index_index %>
-                        <% last_subdef_index_index = subdef_index %>
-                        <span class="subdef-index"><%== subdef_index %>
-                      <% end %>
-                    </td>
-
-                    <td><%== q %></td >
-
-                  </tr>
-                  <% end %>
-                <% end %>
-              <% end %>
-
-        	<% end %>
+      <% end %>
     </table>
   </div>
+  <%
+=end
+  %>
+
+
 
   <%# Get supplement and display %>
   <% show_sups = true %>
   <% sups = ent.supplements %>
-  <% show_sups = ! (sups.nil? || sups.empty?) %>
+  <% show_sups = !(sups.nil? || sups.empty?) %>
 
-  <%# binding.pry %>
 
   <% if show_sups %>
     <h3 class="entry-supplemental-title">Supplemental Materials (draft)</h3>
     <div class="table-responsive entry-supplement">
       <table class="table">
-          <% sups.each do |sup|  %>
-            <%# notes = sup.notes %>
-            <%# notes.each do |note| %>
-              <tr>
-                <td></td><td><%== doc_presenter.supplement_html(sup) %></td>
-              </tr>
-            <%# end %>
-          <% end %>
+        <% sups.each do |sup| %>
+          <%# notes = sup.notes %>
+          <%# notes.each do |note| %>
+          <tr>
+            <td></td>
+            <td><%== doc_presenter.supplement_html(sup) %></td>
+          </tr>
+          <%# end %>
+        <% end %>
       </table>
     </div>
   <% end %>
 
-</div>
+  </div>

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -27,12 +27,16 @@
 
   <div class="table-responsive entry-info">
     <table class="table table-striped">
-      <tr><td class="forms-title">Forms</td><td class="forms-list"><% ent.all_forms.each_with_index do |(k, v)|  %><%= k %><%= "," if k != ent.all_forms.last %>&nbsp;&nbsp;<% end %></td></tr>
+      <tr><td class="forms-title">Forms</td><td class="forms-list">
+        <%# binding.pry %>
+        <%# ent.all_forms.each_with_index do |(k, v)|  %><%#= k %><%#= "," if k != ent.all_forms.last %><%# end %>
+          <%== doc_presenter.form_html %>
+        </td></tr>
       <tr><td class="etymology-title">Etymology</td><td class="etymology-list">
-          <% etym_xml = Nokogiri::XML(ent.etym_xml) %>
-          <% etym_xslt = Nokogiri::XSLT(File.read('./indexer/xslt/EtymOnly.xsl'))%>
-          <% current_etym = etym_xslt.apply_to(etym_xml) %>
-          <%== current_etym %>
+          <%# etym_xml = Nokogiri::XML(ent.etym_xml) %>
+          <%# etym_xslt = Nokogiri::XSLT(File.read('./indexer/xslt/EtymOnly.xsl'))%>
+          <%# current_etym = etym_xslt.apply_to(etym_xml) %>
+          <%== doc_presenter.etym_html %>
       </td></tr>
     </table>
   </div>
@@ -48,10 +52,7 @@
             <tr>
                 <td class="senses-index"><%= sen.sense_number.to_s %></td>
                 	<td class="senses-defintion">
-                  <% def_xml = Nokogiri::XML(sen.definition_xml) %>
-                  <% def_xslt = Nokogiri::XSLT(File.read('./indexer/xslt/DefOnly.xsl')) %>
-                  <% current_def = def_xslt.apply_to(def_xml) %>
-                  <%== current_def %>
+                    <%== doc_presenter.def_html(sen) %>
                 </td>
                 <td  class="quotes-control">
 
@@ -59,7 +60,8 @@
                   <% jq_show_class = "show_" + sen.sense_number.to_s  %>
                   <% jq_hide_class = "hide_" + sen.sense_number.to_s  %>
 
-                  <% quotes, quote_count = med_quotes_help(sen) %>
+                  <% quotes, quote_count = med_quotes_help(sen, doc_presenter) %>
+
 
                   <% if !quotes.empty? && quote_count > 0 %>
                     <% quote_show_string = (quote_count == 1) ?  "Show Quote" : "Show #{quote_count} " + "Quote".pluralize(quote_count) %>
@@ -103,17 +105,19 @@
   <% sups = ent.supplements %>
   <% show_sups = ! (sups.nil? || sups.empty?) %>
 
+  <%# binding.pry %>
+
   <% if show_sups %>
     <h3 class="entry-supplemental-title">Supplemental Materials (draft)</h3>
     <div class="table-responsive entry-supplement">
       <table class="table">
           <% sups.each do |sup|  %>
-            <% notes = sup.notes %>
-            <% notes.each do |note| %>
+            <%# notes = sup.notes %>
+            <%# notes.each do |note| %>
               <tr>
-                <td></td><td><%== note %></td>
+                <td></td><td><%== doc_presenter.supplement_html(sup) %></td>
               </tr>
-            <% end %>
+            <%# end %>
           <% end %>
       </table>
     </div>

--- a/app/views/catalog/show_entry/_sense.html.erb
+++ b/app/views/catalog/show_entry/_sense.html.erb
@@ -1,0 +1,81 @@
+<%# We pass in
+        * the sense,
+        * its index in the senses array (zero-based),
+        * and the document presenter (for access to the #*_html methods).
+
+
+      A sense has
+        * a sense-number
+        * a definition
+        * zero or more EGs (citations/quotations)
+        * a javascript mechanism for hiding/expanding the egs
+%>
+
+
+
+<style>
+
+  .collapsed {
+    display: none;
+  }
+
+  .sense-number {
+    width: 2.4em;
+    float: left;
+    border: 1pt solid red;
+  }
+
+  .definition {
+    border: 1pt solid green;
+    margin-left: 2.5em;
+  }
+
+  .quote-toggles {
+    float: right;
+    position: bottom;
+    border: 1pt solid blue;
+  }
+
+  .sense {
+    padding-bottom: 2em;
+  }
+
+</style>
+
+
+<%
+  num_citations = sense.egs.flat_map(&:quotes).size
+  uid = [sense.sense_number.to_s, index, 'toggle'].join('-')
+%>
+
+<div class="sense">
+
+
+  <div>
+    <div class="sense-number"><%= sense.sense_number %></div>
+    <div class="definition"><%== presenter.def_html(sense) %>
+
+    <span class="quote-toggles">
+      <a class="quote-toggle <%= uid %>" href="#" onClick="$('.<%= uid%>').toggle(); return false">Show&nbsp;<%= num_citations %>&nbsp;<%= "Quote".pluralize(num_citations) %></a>
+      <a class="quote-toggle  <%= uid %> collapsed" href="#" onClick="$('.<%= uid%>').toggle(); return false">Hide&nbsp;<%= num_citations %>&nbsp;<%= "Quote".pluralize(num_citations) %></a>
+    </span>
+    </div>
+  </div>
+
+  <div class="egs">
+    <% sense.egs.each do |eg| %>
+      <div class="eg collapsed <%= uid %>">
+        <div class="subdef-entry-number"><%= eg.subdef_entry %></div>
+        <div class="citations">
+          <ul>
+            <% eg.citations.each do |cite| %>
+              <li><%== presenter.citation_html(cite) %></li>
+            <% end %>
+          </ul>
+        </div>
+
+      </div>
+    <% end %>
+  </div>
+
+</div>

--- a/indexer/main_indexing_rules.rb
+++ b/indexer/main_indexing_rules.rb
@@ -1,5 +1,3 @@
-
-
 $LOAD_PATH.unshift Pathname.new(__dir__).to_s
 $LOAD_PATH.unshift (Pathname.new(__dir__).parent + 'lib').to_s
 require 'annoying_utilities'
@@ -19,7 +17,7 @@ end
 # Do a terrible disservice to traject and monkeypatch it to take
 # our existing logger
 
-Traject::Indexer.send(:define_method, :logger, ->() {AnnoyingUtilities.logger })
+Traject::Indexer.send(:define_method, :logger, ->() {AnnoyingUtilities.logger})
 
 
 def entry_method(name)
@@ -77,6 +75,14 @@ to_field('doe_norm') do |entry, acc|
   acc << entry.doelinks.normalized_term if entry.doelinks
 end
 
+# Citations
+
+to_field('citation_text') do |entry, acc|
+  entry.all_citations.each do |c|
+    acc << c.text
+  end
+end
+
 # Quotes
 to_field('quote_text') do |entry, acc|
   acc.replace entry.all_quotes.map(&:text)
@@ -96,6 +102,13 @@ to_field('cd') do |entry, acc|
   acc.replace entry.all_citations.flat_map(&:cd).uniq.compact
 end
 
+to_field('min_md') do |entry, acc|
+  acc << entry.all_citations.flat_map(&:md).compact.min
+end
+
+to_field('min_cd') do |entry, acc|
+  acc << entry.all_citations.flat_map(&:cd).compact.min
+end
 
 # Notes
 to_field 'notes', entry_method(:notes)

--- a/indexer/writers/localhost.rb
+++ b/indexer/writers/localhost.rb
@@ -6,7 +6,7 @@ require 'annoying_utilities'
 
 settings do
   provide "solr.url", AnnoyingUtilities.solr_url
-  provide "solr_writer.commit_on_close", "true"
+  provide "solr_writer.commit_on_close", "false"
   provide "solr_writer.thread_pool", 2
   provide "solr_writer.batch_size", 200
   provide "writer_class_name", "Traject::SolrJsonWriter"

--- a/lib/med_installer/index.rb
+++ b/lib/med_installer/index.rb
@@ -41,6 +41,20 @@ module MedInstaller
 
         puts $?.exitstatus
 
+
+        logger.info "Completed indexing. Sending commit and rebuilding autocompletes (long!)"
+
+        core = AnnoyingUtilities.solr_core
+
+        # Commit with index building can take a looooong time. Set the timeout to 100seconds
+        core.rawclient.receive_timeout = 200_000 # 200 seconds
+        core.commit
+
+        logger.info "Optimizing solr index. Even longer!"
+        core.optimize
+
+        logger.info "Process complete"
+
       end
     end
 

--- a/solr/med/conf/schema.xml
+++ b/solr/med/conf/schema.xml
@@ -211,14 +211,22 @@
   <!-- Notes -->
   <field name="notes" type="text" indexed="true" stored="true" multiValued="true"/>
 
+  <!-- Full citation text, including quotes, but not in me_text -->
+
+  <field name="citation_text" type="text" indexed="true" stored="true" multiValued="true"/>
+
   <!-- Quotes -->
   <field name="quote_text"  type="me_text" indexed="true" stored="true" multiValued="true"/>
   <field name="quote_title" type="me_text" indexed="true" stored="true" multiValued="true"/>
   <field name="quote_manuscript" type="text" indexed="true" stored="true" multiValued="true"/>
   <field name="quote_date" type="string" indexed="false" stored="true" multiValued="true"/>
   <field name="rid" type="string" indexed="true" stored="true" multiValued="true"/>
+
+  <!--Dates-->
   <field name="md" type="int" indexed="true" stored="true" multiValued="true"/>
   <field name="cd" type="int" indexed="true" stored="true" multiValued="true"/>
+  <field name="min_md" type="int" indexed="true" stored="true" multiValued="true"/>
+  <field name="min_cd" type="int" indexed="true" stored="true" multiValued="true"/>
 
 
   <!-- Usage -->

--- a/solr/med/conf/solrconfig.xml
+++ b/solr/med/conf/solrconfig.xml
@@ -6,7 +6,10 @@
         <!ENTITY headword_only_search   SYSTEM "solrconfig_med/headword_only_search.xml">
         <!ENTITY headword_and_forms_search   SYSTEM "solrconfig_med/headword_and_forms_search.xml">
         <!ENTITY everything_search   SYSTEM "solrconfig_med/everything_search.xml">
+        <!ENTITY citation_search SYSTEM "solrconfig_med/citation_search.xml">
+
         <!ENTITY highlighting_defaults   SYSTEM "solrconfig_med/highlighting.xml">
+
         <!ENTITY headword_only_suggester SYSTEM "solrconfig_med/suggesters/headword_only_suggester.xml">
         <!ENTITY headword_and_forms_suggester SYSTEM "solrconfig_med/suggesters/headword_and_forms_suggester.xml">
         <!ENTITY oed_suggester SYSTEM "solrconfig_med/suggesters/oed_suggester.xml">
@@ -53,6 +56,7 @@
       &headword_only_search;
       &everything_search;
       &highlighting_defaults;
+      &citation_search;
 
 
 

--- a/solr/med/conf/solrconfig_med/citation_search.xml
+++ b/solr/med/conf/solrconfig_med/citation_search.xml
@@ -1,0 +1,9 @@
+<str name="citation_qf">
+  quote_text^10
+  citation_text
+</str>
+
+<str name="citation_pf">
+  quote_text^10
+  citation_text
+</str>

--- a/solr/med/conf/solrconfig_med/suggesters/doe_suggester.xml
+++ b/solr/med/conf/solrconfig_med/suggesters/doe_suggester.xml
@@ -6,7 +6,7 @@
   <str name="buildOnCommit">true</str>
   <str name="field">doe_norm</str>
   <str name="exactMatchFirst">true</str>
-  <str name="buildOnStartup">true</str>
+  <str name="buildOnStartup">false</str>
   <str name="minPrefixChars">2</str>
   <str name="dictionaryImpl">DocumentDictionaryFactory</str>
   <str name="buildOnCommit">true</str>

--- a/solr/med/conf/solrconfig_med/suggesters/headword_and_forms_suggester.xml
+++ b/solr/med/conf/solrconfig_med/suggesters/headword_and_forms_suggester.xml
@@ -7,7 +7,7 @@
     <str name="buildOnCommit">true</str>
     <str name="field">word_suggestions</str>
     <str name="exactMatchFirst">true</str>
-    <str name="buildOnStartup">true</str>
+    <str name="buildOnStartup">false</str>
     <str name="minPrefixChars">2</str>
     <str name="dictionaryImpl">DocumentDictionaryFactory</str>
     <str name="buildOnCommit">true</str>

--- a/solr/med/conf/solrconfig_med/suggesters/headword_only_suggester.xml
+++ b/solr/med/conf/solrconfig_med/suggesters/headword_only_suggester.xml
@@ -7,7 +7,7 @@
     <str name="buildOnCommit">true</str>
     <str name="field">headword_only_suggestions</str>
     <str name="exactMatchFirst">true</str>
-    <str name="buildOnStartup">true</str>
+    <str name="buildOnStartup">false</str>
     <str name="minPrefixChars">2</str>
     <str name="dictionaryImpl">DocumentDictionaryFactory</str>
     <str name="buildOnCommit">true</str>

--- a/solr/med/conf/solrconfig_med/suggesters/oed_suggester.xml
+++ b/solr/med/conf/solrconfig_med/suggesters/oed_suggester.xml
@@ -6,7 +6,7 @@
   <str name="buildOnCommit">true</str>
   <str name="field">oed_norm</str>
   <str name="exactMatchFirst">true</str>
-  <str name="buildOnStartup">true</str>
+  <str name="buildOnStartup">false</str>
   <str name="minPrefixChars">2</str>
   <str name="dictionaryImpl">DocumentDictionaryFactory</str>
   <str name="buildOnCommit">true</str>


### PR DESCRIPTION
Use XSL Transforms to display data

Change display of data in the Show page for a dictionary
entry to use XSL transforms found in `indexer/xslt`.

* Changes to the presenter to generate XML nodes that
        can be transformed and then provide the raw HTML
        to the views
* Split the Show view into a couple files to make it
        easier to read
* Change the expand/collapse javascript to target the
        entire block that needs hiding.