### PR TITLE
Move solr config to solr/config

### DIFF
--- a/solr/config
+++ b/solr/config
@@ -1,0 +1,1 @@
+med/conf


### PR DESCRIPTION
Puts the solr configuration where we expect it to be for deployment.