### PR TITLE
Move autocomplete config to a config file

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -306,33 +306,8 @@ class CatalogController < ApplicationController
     # mean") suggestion is offered.
     config.spell_max = 15
 
-    # Configuration for autocomplete suggestor
-    config.autocomplete_enabled = true
-    config.autocomplete_path    = 'headword_and_forms_suggester'
 
-    # Autocomplete setup.
-    # The format is:
-    #   search_name: {
-    #     solr_endpoint: path_to_solr_handler,
-    #     search_component_name: "mySuggester"
-    #       }
-    #
-    # The "search_name" is the name given the search in the
-    # `config.add_search_field(name, ...)` above.
-    #
-    config.autocomplete = {
-      h:   {
-        solr_endpoint:         "headword_only_suggester",
-        search_component_name: "headword_only_suggester"
-      },
-      hnf: {
-        solr_endpoint:         "headword_and_forms_suggester",
-        search_component_name: "headword_and_forms_suggester"
-      },
-      oed: {
-        solr_endpoint:         "oed_suggester",
-        search_component_name: "oed_suggester"
-      }
-    }
+    # Autocomplete on multiple fields. See config/autocomplete.yml
+    config.autocomplete = Rails.application.config_for(:autocomplete)
   end
 end

--- a/config/autocomplete.yml
+++ b/config/autocomplete.yml
@@ -1,0 +1,31 @@
+# Autocomplete setup.
+# The format is:
+#   search_name:
+#     solr_endpoint: path_to_solr_handler
+#     search_component_name: mySuggester
+#
+# The search_name is the name given the search in the
+# `config.add_search_field(name, ...)` in catalog_controller
+
+
+
+default: &default
+  h:
+    solr_endpoint:         headword_only_suggester
+    search_component_name: headword_only_suggester
+  hnf:
+    solr_endpoint:         headword_and_forms_suggester
+    search_component_name: headword_and_forms_suggester
+  oed:
+    solr_endpoint:         oed_suggester
+    search_component_name: oed_suggester
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default
+

--- a/lib/med_installer/solr.rb
+++ b/lib/med_installer/solr.rb
@@ -47,7 +47,22 @@ module MedInstaller
         end
 
         core.reload
-        resp = core.get "/search", {'q'=>'*:*', 'rows'=>0,"suggest.build" => true}
+
+        # Reload all the suggester
+
+        envenv = ENV['RAILS_ENV']
+        env = if envenv.nil? or envenv.empty?
+                'development'
+              else
+                envenv
+              end
+        logger.info "Recreating suggest indexes for #{env} environment"
+        autocomplete = AnnoyingUtilities.load_config_file('autocomplete.yml')[env]
+        autocomplete.keys.each do |key|
+          suggester_path = autocomplete[key]["solr_endpoint"]
+          logger.info "   Recreate suggester for #{suggester_path}"
+          resp = core.get "/#{suggester_path}", {'suggest.build' => 'true'}
+        end
         logger.info "Core at '#{core.url}' reloaded"
 
       end


### PR DESCRIPTION
Necessary to be able to read the solr suggest paths and rebuild the suggest indexes.