### PR TITLE
Rationalize hyp_to_bibID

### DIFF
--- a/app/presenters/dromedary/index_presenter.rb
+++ b/app/presenters/dromedary/index_presenter.rb
@@ -81,7 +81,7 @@ module Dromedary
     # @return [String, nil] The citatation transformed into HTML, or nil
     def cit_html(cit)
       rid = cit.bib.stencil.rid
-      bibid = Dromedary::HYP_TO_BIBID[rid.upcase]
+      bibid = Dromedary.hyp_to_bibid[rid.upcase]
       xsl_transform_from_xml(cit.xml, CIT_XSLT, ["bibid", "'#{bibid}'"])
     end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,9 @@ module Dromedary
     # -- all .rb files in that directory are automatically loaded.
   end
 
-  HYP_TO_BIBID = JSON.load(File.open("#{Rails.root}/config/hyp_to_bibid.json"))
+
+  def self.hyp_to_bibid
+    @hyp_to_bibid ||= JSON.load(File.open("#{Rails.root}/config/hyp_to_bibid.json"))
+  end
+
 end


### PR DESCRIPTION
Make a mapping of RIDs  ("HYP..." identifiers) to BibIDs on index and stick it in the 
`config` directory for use when rendering quotations.