### PR TITLE
Changes to text and links

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -163,6 +163,11 @@ ul.header-nav-secondary a:focus {
  .splash-detail--heading {
     padding-bottom: .5em;
     font-size: 1.25em;
+
+   a, a:visited {
+     text-decoration: none;
+     color: inherit;
+   }
  }
 
   .splash-detail--light {
@@ -214,6 +219,12 @@ ul.header-nav-secondary a:focus {
 .nav-detail--heading {
   padding-bottom: .5em;
   font-size: 1.25em;
+  
+  a, a:visited {
+    text-decoration: none;
+    color: inherit;
+  }
+
 }
 
 .nav-detail--light {

--- a/app/controllers/quotes_controller.rb
+++ b/app/controllers/quotes_controller.rb
@@ -44,7 +44,7 @@ class QuotesController < ApplicationController
 
 
 
-    config.add_search_field("quote_everything", label: "Entire citation") do |field|
+    config.add_search_field("quote_everything", label: "Stencil and quotation") do |field|
       field.qt                    = "/quotesearch"
       field.solr_local_parameters = {
           qf: '$quote_everything_qf',
@@ -52,7 +52,7 @@ class QuotesController < ApplicationController
       }
     end
 
-    config.add_search_field("quote_quote", label: "Quote text") do |field|
+    config.add_search_field("quote_quote", label: "Quotation text only") do |field|
       field.qt                    = "/quotesearch"
       field.solr_local_parameters = {
           qf: '$quote_quote_qf',

--- a/app/views/_secondary_util_links.html.erb
+++ b/app/views/_secondary_util_links.html.erb
@@ -12,5 +12,5 @@
    <li class="<%= is_med%>"><%= render partial: 'shared/nav/med' %></li>
    <li class="<%= is_bib%>"><%= render partial: 'shared/nav/bib' %></li>
    <li class="<%= is_quotes%>"><%= render partial: 'shared/nav/quotes' %></li>
-   <li><%= render partial: 'shared/nav/corpus' %></li>
+
 </ul>

--- a/app/views/bibliography/home.html.erb
+++ b/app/views/bibliography/home.html.erb
@@ -17,7 +17,7 @@
 	  English bibliiographies accessible through the <a href="">Middle English Compendium</a>.
 	</div>
 
-	<div class="search-bar-label">Search for Bibliographic entries that include:</div>
+	<div class="search-bar-label">Search bibliographic entries:</div>
 	<div class="search-bar--light-bg">
 	  <%= render_search_bar  %>
 	</div>

--- a/app/views/catalog/_index_header_entry.html.erb
+++ b/app/views/catalog/_index_header_entry.html.erb
@@ -29,7 +29,7 @@
         <% end %>
 
         <div class="index-quotes-line">
-          <%= "#{doc_presenter.quote_count} quotation".pluralize(doc_presenter.quote_count) + " on #{doc_presenter.senses.count}" + " sense".pluralize(doc_presenter.senses.count) %>
+          <%= "#{doc_presenter.quote_count} quotation".pluralize(doc_presenter.quote_count) + " in #{doc_presenter.senses.count}" + " sense".pluralize(doc_presenter.senses.count) %>
         </div>
 
 

--- a/app/views/catalog/home.html.erb
+++ b/app/views/catalog/home.html.erb
@@ -23,23 +23,23 @@
 			<div class="col-sm-12 padding0">
 					<div class="col-sm-4">
 						<ul>
-							<li class="nav-detail--heading">How to get started</li>
+              <li class="nav-detail--heading"><a href="/static/help_getting_started">How to get started</a></li>
 							<li class="nav-detail--light">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt.</li>
-							<li class="nav-detail--link"><a href="">Getting started</a></li>
+							<li class="nav-detail--link"><a href="/static/help_getting_started">Getting started</a></li>
 						</ul>
 					</div>
 					<div class="col-sm-4">
 						<ul>
-							<li class="nav-detail--heading">More ways to search</li>
+              <li class="nav-detail--heading"><a href="/static/about_med">More ways to search</a></li>
 							<li class="nav-detail--light">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt.</li>
-							<li class="nav-detail--link"><a href="">Learn about advanced search options</a></li>
+							<li class="nav-detail--link"><a href="/static/help_search">Learn about advanced search options</a></li>
 						</ul>
 					</div>
 					<div class="col-sm-4">
 						<ul>
-							<li class="nav-detail--heading">History of the MED</li>
+              <li class="nav-detail--heading"><a href="/static/about_med">History of the MED</a></li>
 							<li class="nav-detail--light">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt.</li>
-							<li class="nav-detail--link"><a href="">Read more about's the MED's history</a></li>
+							<li class="nav-detail--link"><a href="/static/about_med">Read more about's the MED's history</a></li>
 						</ul>
 				</div>
 			</div>

--- a/app/views/catalog/splash.html.erb
+++ b/app/views/catalog/splash.html.erb
@@ -10,8 +10,8 @@
   <section class="splash-section">
           
                   <ul class="splash-list">
-                    <li class="splash-detail--heading">Middle English
-                      Dictionary
+                    <li class="splash-detail--heading"><a href="/dictionary">Middle English
+                      Dictionary</a>
                     </li>
                     <li class="splash-detail--light">The world's largest searchable database
                       of Middle English lexicon and usage for the period 1100-1500.
@@ -23,28 +23,17 @@
                   </ul>
             
                   <ul class="splash-list">
-                    <li class="splash-detail--heading">Bibliography</li>
-                    <li class="splash-detail--light">Lorem ipsum dolor sit amet,
-                      consectetur adipiscing elit, sed do eiusmod tempor
-                      incididunt. Lorem ipsum dolor sit amet,
-                      consectetur adipiscing elit, sed do eiusmod tempor
-                      incididunt. Lorem ipsum dolor sit amet.
+                    <li class="splash-detail--heading"><a href="/bibliography">Bibliography</a></li>
+                    <li class="splash-detail--light">A description of the authors,
+                      works, manuscripts, and editions cited in the Dictionary,
+                      the Bibliography also defines the abbreviated forms
+                      under which those works are referred to,
+                      and provides cross-references to major reference sites to allow further study.
                     </li>
                     <li class="splash-detail--link">
                       <a href="/bibliography">Go to the Bibliography</a></li>
                   </ul>
            
-                  <ul class="splash-list">
-                    <li class="splash-detail--heading">Corpus</li>
-                    <li class="splash-detail--light">Lorem ipsum dolor sit amet,
-                      consectetur adipiscing elit, sed do eiusmod tempor
-                      incididunt. Lorem ipsum dolor sit amet,
-                      consectetur adipiscing elit, sed do eiusmod tempor
-                      incididunt. Lorem ipsum dolor sit amet.
-                    </li>
-                    <li class="splash-detail--link">
-                      <a href="https://quod.lib.umich.edu/c/cme/">Go to the Corpus</a></li>
-                  </ul>
           </section>
      
  	

--- a/app/views/layouts/static.html.erb
+++ b/app/views/layouts/static.html.erb
@@ -10,8 +10,6 @@
 
     </div>
 
-    <%#= render partial: '/catalog/back_to_top' %>
-
 
   <% end %>
 

--- a/app/views/quotes/home.html.erb
+++ b/app/views/quotes/home.html.erb
@@ -8,14 +8,19 @@
 
 <%# require 'pry'; binding.pry %>
 
+
 <section class="quotations-home">
 	<h1>MEC Quotation Search</h1> 
 	<div class="home-description">
-	 <p>Quotations illustrate the use of a word. This search helps you find a designated form, word, phrase or combination of words within stencils and quotations. Find out more in the <a href="/static/help_med#quotes">MEC Quotation Search Help</a> guide.</p>
-	</div>
+<p>  Quotations illustrate the use of a word.
+  This search helps you find a designated word,
+  phrase, or combination of words within
+  stencils and quotations.</p>
+  </div>
 
-	<div class="search-bar-label">Search for Quotation entries that include:</div>
+	<div class="search-bar-label">Search quotations:</div>
 	<div class="search-bar--light-bg">
 	  <%= render_search_bar  %>
 	</div>
 </section>
+

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,9 +3,9 @@
     <section>
       <ul>
         <li class="heading-medium">Middle English Compendium</li>
-        <li><a href="<%=root_path %>">Middle English Dictionary</a></li>
-        <li><a href="https://quod.lib.umich.edu/h/hyperbib/">Bibliography</a></li>
-        <li><a href="https://quod.lib.umich.edu/c/cme/">Corpus of Middle English Prose and Verse</a></li>
+        <li><a href="/dictionary">Middle English Dictionary</a></li>
+        <li><a href="/bibliography">Bibliography</a></li>
+        <li><a href="https://quod.lib.umich.edu/c/cme/">Corpus</a></li>
       </ul>
      </section>
     <section>

--- a/app/views/static/_about_sidebar.html.erb
+++ b/app/views/static/_about_sidebar.html.erb
@@ -1,9 +1,14 @@
 <div id="about_sidebar" class="<%= sidebar_classes %> about-sbar">
   <div class="sidebars">
-    <h2>About</h2>
+    <h2>About the Middle English Compendium</h2>
     <ul class="help-ul">
-      <%= render partial: 'static/help_sidebar_link', locals: { path: 'about_med', label: "About the MED" } %>
-      <%= render partial: 'static/help_sidebar_link', locals: { path: '/catalog', label: "Back to Search" } %>
+      <li><a href="#med">Middle English Dictionary</a></li>
+      <li><a href="#bib">"Hyper"Bibliography</a></li>
+      <li><a href="#corpus">Corpus of Middle English Prose and Verse</a></li>
+      <li><a href="#acknowledgements">Acknowledgements</a></li>
+      <li><a href="#notes">Notes</a></li>
+      <%#= render partial: 'static/help_sidebar_link', locals: { path: 'about_med', label: "About the MED" } %>
+      <%#= render partial: 'static/help_sidebar_link', locals: { path: '/catalog', label: "Back to Search" } %>
       <%#= render partial: 'static/help_sidebar_link', locals: { path: 'about_project', label: "About the Digital Archives Project" } %>
       <%#= render partial: 'static/help_sidebar_link', locals: { path: 'rights', label: "Rights Statement" } %>
     </ul>

--- a/app/views/static/about_med.html.erb
+++ b/app/views/static/about_med.html.erb
@@ -1,89 +1,98 @@
-<% @page_title = t('en.views.static.about-med.title') %>
+<% @page_title = t('views.static.about-med.title') %>
 
 <div class="container">
   <div>
     <%= render partial: 'about_sidebar' %>
 
     <div id="med" class="<%= main_content_classes %> about-middle-col">
-      <h1 class="title">About</h1>
-        <p class="about-lg">Learn more about the Middle English Compendium, The Middle English Dictionary (MED), the HyperBibliography, and the Corpus of Middle English. Find information about rights and how to contact us.</p>
 
-      <H3><A NAME="ov"></A>About the Middle English Compendium</H3>
+      <h1 id="about">About the Middle English Compendium</h1>
 
-      <p><em>The Middle English Compendium</em> has been designed to
-      offer easy access to and interconnectivity between three major
-      Middle English electronic resources: an electronic version of the
-      Middle English Dictionary, a HyperBibliography of Middle English
-      prose and verse based on the MED bibliographies, a Corpus of Middle
-      English Prose and Verse, as well as links to an
-      associated network of electronic resources. Hypertext links offer quick
-      connections between, e.g., an MED citation, bibliographical
-      information about its source, and an electronic version of the
-      source, if one is included in the collection (we
-      hope eventually to have electronic versions of all the source texts).</p>
-
-      <H3><A NAME="med"></A>About The Electronic Middle English Dictionary </H3>
-
-      <P>The print <EM>Middle English Dictionary</EM>, now complete,
-      has been described as &quot;the greatest achievement
-      in medieval scholarship in America.&quot; Its 15,000
-      pages offer a comprehensive analysis of lexicon and usage for
-      the period 1100-1500, based on the analysis of a collection of
-      over three million citation slips, the largest collection of this
-      kind available. This electronic version of the MED preserves all
-      the details of the print MED, but goes far beyond this, by
-      converting its contents into an enormous database, searchable in
-      ways impossible within any print dictionary.</P>
+      <p>The Middle English Compendium is a publication of the University of Michigan Library, the latest embodiment of the University's long-standing involvement in the study of Middle English. The Compendium has been designed to offer easy access to and some interconnectivity between three major Middle English electronic resources: an electronic version of the <i>Middle English Dictionary </i>(MED); a <i>Bibliography</i> of Middle English primary texts, limited to those cited by the MED and based on the MED bibliographies; and a searchable full-text <i>Corpus</i> of Middle English prose and verse.</p>
 
 
-      <H3><A NAME="hyp"></A>About The HyperBibliography of Middle English</H3>
+      <h2 id="med">The Middle English Dictionary</h2>
 
-      <P>The <EM>HyperBibliography of Middle English</EM> includes all
-      the Middle English materials which are cited in the Middle
-      English Dictionary. Although this bibliography is not exhaustive,
-      it offers what we believe to be the most comprehensive single
-      list of these materials available. Titles have been adopted from
-      <EM>A Manual of the Writings in Middle English</EM> whenever possible, and
-      are followed by the MED stencil (short title) in brackets. Once
-      you retrieve a list of works or authors or manuscripts by
-      browsing or searching, click on any item to move to a page of
-      information about manuscripts, editions, bibliographical
-      references, and MED title stencils. </P>
+      <p>At the heart of the Compendium is a digital version of the Middle English Dictionary, which both reproduces and extends the print MED (issued in 115 parts and approximately 15,000 pages by the University of Michigan Press, 1952-2001). Those looking for an account of the print MED, both the history of the MED Project (1925-2000) and the policies, scope, and conventions of the dictionary as published, should probably begin with the MED's own <i>Plan and Bibliography,</i> 2nd edition, compiled by Robert E. Lewis and Mary Jane Williams (UM Press, 2007), "an indispensable guide to the complex and unexpectedly unstable text of the MED"<a href="#note1"><sup>1</sup></a>; followed by the special issue of <i>Dictionaries,</i> number 23 (2002), devoted in its entirety to a celebration of the completion of the print MED. Understanding the strengths and weaknesses, scope and limitations, and conventions and occasional reticence of the online MED requires some familiarity with those of the print, since the online version largely reproduces the print. The essential facts about the MED in both versions are</p>
 
-
-      <H3><A NAME="corp"></A>Corpus of Middle English Prose and Verse</H3>
-
-      <P>The Humanities Text Initiative intends to develop the <EM>Corpus
-      of Middle English Prose and Verse </EM>into an extensive and
-      reliable collection of Middle English electronic texts, either by
-      converting the texts ourselves or by negotiating access to other
-      collections produced to specified high standards of accuracy. At
-      present, sixty-two texts are available; about eighty others will be
-      added soon, with another 150 smaller texts in preparation.
-      HTI would like to include in the corpus all editions of
-      Middle English texts used in the MED, and the more recent
-      scholarly editions which in some cases may have superseded them.
-      The Corpus is provided with a full array of search mechanisms,
-      and texts may be searched individually, in user designated
-      groups, or collectively.</P>
-      
-      
-      <H3><A NAME="staff"></A>Compendium Staff</H3>
-      <ul class="compendium-staff">
-        <li>Frances McSparran, Chief Editor<br> <span class="title-secondary">Associate Professor of English, University of Michigan</li>  
-        <li>Paul Schaffner, Associate Editor<br> <span class="title-secondary">Coordinator, Text-encoding group, DLPS*</li>  
-        <li>John Latta<br> <span class="title-secondary">Text and markup editor, DLPS</li>
-        <li>Alan Pagliere <br> <span class="title-secondary">Programmer, DLPS</li>
-        <li>Christina Powell <br> <span class="title-secondary">Coordinator, Encoded text services, DLPS</li>
-        <li>Matt Stoeffler <br> <span class="title-secondary">Interface designer, DLPS</span></li>
+      <ul>
+        <li>that it is wholly evidence-based, working from a fresh reading of approximately 3,000,000 quotations extracted from primary sources;</li>
+        <li>that though it covers an historical period (roughly 1175-1500), the entries themselves are arranged more logically than historically (e.g. from concrete to figurative and from simple to extended senses, rather than from earlier senses to later ones);</li>
+        <li>that the evidence it presents consists as much as possible of actual manuscript readings rather than editorial conjectures, the primary date assigned to that evidence being the date of the manuscript in question; </li>
+        <li>that though it does not exclude any evidence, and is by far the most comprehensive treatment of Middle English vocabulary, the size of the Middle English extant corpus (and the fact that much of it remains unedited) mean that it cannot hope to be exhaustive;</li>
+        <li>that like all dictionaries it needs to be taken as a careful assembling of incomplete evidence rather than as a final authority, to be used with caution, and with due regard to the likelihood of error and inconsistency;</li>
+        <li>that when using MED, a reader should also bear in mind the multilingual character of medieval Britain and the inter-lingual character of much of its vocabulary, ready when needed to consult sibling dictionaries of Scots, Continental and Anglo-French, and Latin at least, and sometimes Dutch, Norse, and Welsh as well;</li>
+        <li>and that a reader should of course also bear in mind the larger history of individual words, by recourse as needed to the Dictionary oF Old English and the Oxford English Dictionary, as well as various etymological and specialist dictionaries. </li>
       </ul>
 
-      <P>Earlier stages of the project received invaluable contributions from Maria Bonn (interface design and documentation), Nigel Kerr (programming), James Moske (MED conversion and HyperBibliography editing), David Ruddy (HyperBibliography production and project design), and especially the head of DLPS, John Price Wilkin (Project Director, grant period), among others.
-      </p><p>*MEC is a product of the University of Michigan Digital Library Production Service.</p>
+      <h3>The online MED 2000</h3>
 
-        <h3>Rights Statement</h3>
+      <p>The online MED, on which work began in 1997 under the direction of Prof. Frances McSparran, and which was published for the first time in 2000, was a close facsimile of the print MED, with the exception that (1) a few incidental errors were corrected; (2) bibliographic details about quoted sources (manuscript dates and shelfmarks especially, as they were known in 2001) were updated and retroactively applied to the entire dictionary; and (3) many short citation forms ('stencils'), which in the print MED were often succinct to the point of being cryptic, were made to state some of their implicit information more verbosely and explicitly, e.g. which manuscript they referred to. The online MED was, however, careful to take no editorial liberties with the text of the MED, so that users accustomed to quoting the print Dictionary could use and quote the online version with confidence that they were quoting, in effect, 'the same thing' --albeit in improved form.</p>
 
-        <h3>Contact Us</h3>
+      <h3>Interim developments 2007-20014</h3>
+
+      <p>In 2007, the online MED and its Bibliography, published initially on a subscription basis in order to recoup keying costs, was 'liberated' and made free for all to use without restriction; in the same year, the University Press issued the final <i>Plan and Bibliography</i> (2nd ed.), which incorporated many bibliographic changes already reflected in the online bibliography. In 2013, it added a very incomplete set of links from MED entries to the corresponding entry in the Oxford English Dictionary (OED); in 2014, it similarly linked MED entries to corresponding entries in the Dictionary of Old English (DOE).</p>
+
+      <h3>The online MED revised 2018</h3>
+
+      <p>The revised MED, available for the first time now as a beta release in 2018, represents the first substantial changes to MED for twenty years, thanks to a two-year grant (2016-18) awarded under the Humanities Collections and Reference Resources program of the National Endowment for the Humanities, matched by funds from the University of Michigan Library and an MED gift fund. The plan is that this effort will set in motion a process of ongoing revision, but our immediate goals have been to perform only the most urgent updates, publishing as much supplementary information as we can, even when we can not afford to integrate it fully into the existing online Dictionary. At the very least we have been doing what Robert Lewis promised in 2007, "to correct our obvious errors, to append some additional quotations [and notes to] existing entries, and to add some entirely new entries in the electronic MED." We have been attaching to the appropriate entries additional quotes and notes taken chiefly from two sources: (1) about 20,000 'supplement slips' set aside over decades by the MED editors in hope that an MED Supplement would some day be compiled. These have hitherto lain largely inaccessible in boxes in the university archives. And (2) a much smaller number of new virtual supplement slips drawn from editorial notes in recent editions of ME texts, notes of the sort that typically declare, "this word (or sense, or spelling) omitted by MED"--in effect crowd-sourcing correction of the MED.  This process has added (so far) about 10,000 quotations to the MED, bringing its total corpus of quotations to well over 900,000, as well as about 2,000 new entries, which now total nearly 56,000.</p>
+
+      <h4>The sources of our revision</h4>
+      <table border="1" width="100%">
+        <tr>
+          <td style="width:50%"><a href="<%=asset_url('slip_1.jpg')%>"><img alt="New entry with an abundance of notes" src="<%=asset_url('slip_1.jpg')%>" width="100%"></a></td>
+          <td style="width:50%"><a href="<%=asset_url('slip_2.jpg')%>"><img alt="antedating of sense" src="<%=asset_url('slip_2.jpg')%>" width="100%"></a></td>
+        </tr>
+      </table>
+
+
+      <h4>Data changes</h4>
+
+      <p>We have also continued the long process of removing artifacts of its print origins from the Dictionary, in favor of data that is more amenable to being searched and manipulated by computer. We are expanding some of the implicit and contracted spellings given in the print MED, thereby exposing them to search; and we are completing a nearly comprehensive map of MED to OED lemmas and sub-lemmas, thereby facilitating not only a seamless link to the corresponding OED entry but also a new lookup search of the MED itself by modern English equivalent (mostly to be identified with the OED headword).
+
+        Our larger goal in publishing this revision is to transform the MED from an essentially static resource to an essentially dynamic one, in two respects, editorially, adding the ability to accept, store, and publish additions and corrections; and technically, moving MED to something as close as possible to an 'off-the-shelf' software platform, allowing for frequent updates and future migration of the Dictionary and Compendium data to new platforms (to avoid technical obsolescence) and new functionality, which eventually should allow the data to be opened up for reuse by other products and projects, thus fulfilling the vision that we always had for the MEC as a node in a network of historical dictionaries, electronic editions, text portals, and other linguistic resources.
+
+      <hr>
+
+      <h2 id="bib">"Hyper"Bibliography of Middle English</h2>
+
+      <p>The second component of the Compendium triad is the Bibliography. The MED Bibliography includes, by intention at least, all the Middle English materials and texts which are cited in the Middle English Dictionary. Although this bibliography is not exhaustive, it offers what we believe to be the most comprehensive single list of these materials available. At its core are the two lists of sources published by MED as its original <i>Plan and Bibliography</i> (1954) and its supplementary <i>Plan and Bibliography, Supplement 1</i> (1984), but including also additions and changes made in the final volumes of the print MED, but not documented in print form till the publication of the <i>Plan and Bibliography,</i> second edition (2007), with which it was co-developed.  As it appeared for the first time in 2000, under the title (very much of its time) 'HyperBibliography of Middle English,' the MED Bibliography represented a considerable expansion on the bare handlists issued in print: it added references to some major reference works (the <i>Manual of Writings in Middle English</i>; the <i>Index of Printed ME Prose</i>; the <i>Index of Middle English Verse</i>); spelled out the printed and manuscript sources for variant readings more fully; updated shelfmarks and repository names and expressed them more verbosely; and in many cases added a localization to the manuscript lists based on the findings of the <i>Linguistic Atlas of Late Middle English</i> (LALME) , to which it provided a reference. Functionally, the online Bibliography served not only as a searchable list of manuscripts, works, and editions, but also as what librarians call an 'authority file,' a set of abbreviated bibliographic references which provide the authoritative form of those used in the Dictionary, and a centralized file of expansions and explanations to which every citation in the Dictionary could potentially link, and almost all did.</p>
+
+      <h3>Revised Bibliography, 2018</h3>
+
+      <p>The revisions to the Bibliography have been less dramatic than those to the MED itself: a few errors have been corrected; a few obsolete MS shelfmarks have been updated; but most of the changes have been simple additions: more than a hundred new editions, mostly those that have appeared in the last two decades, have been added, containing about three hundred new works, bringing the total to about 5,850 and rising, and nearly a thousand new 'stencils' (permutations of work, manuscript, and edition), the necessary framework for citing newly available evidence in the MED.</p>
+
+      <p>Most of the changes to the Bibliography, as to the Dictionary, reflect its transformation from a static list of works quoted into a constantly renewable and updatable resource. The Bibliography now at least acknowledges, though it has not yet made full use of, large-scale digital repositories such as the <i>Parliament Rolls</i> and the <i>Middle English Local Documents</i> database (MELD), as well as recent specialist dictionaries such as J. Norri's <i>Dictionary of Medical Vocabulary </i>. There are now 'hooks' in the Bibliography structure to which additional cross-references to reference works will in time be attached (allowing links especially to the <i>Digital Index of Middle English Verse</i> (DIMEV), the <i>New Index of Middle English Verse</i> (NIMEV), the <i>Index of Middle English Prose</i> (IMEP), and the <i>Linguistic Atlas of Early Middle English</i> (LAEME)), all of which are designed to facilitate navigation amongst these essential resources. And a cooperative effort has been undertaken with the staff of the Oxford English Dictionary to coordinate the re-dating of manuscripts in tandem, not only so as to make our testimony agree, but to facilitate greater integration between MED and OED.</p>
+
+      <hr>
+
+      <h2 id="corpus">Corpus of Middle English Prose and Verse</h2>
+
+      <p>The third component of the Compendium, the Corpus, does not pretend to be a 'corpus' as a linguist would define it, but is simply a collection of searchable Middle English text, assembled, indexed, and made searchable, created largely by re-keying and adding basic structural markup to out-of-copyright (public domain) editions. This principle of selection allows the Library to distribute it as a public service without fee or restriction.<a href="#note2"><sup>2</sup></a> The body of quotations cited by the MED constitutes a searchable corpus in its own right; the full-text Corpus component of the Compendium is intended as ancillary to that, allowing one, for example, to search for phrases and collocations in a larger body of material. </p>
+
+      <h3>Growth of the Corpus</h3>
+      <p>The original Corpus consisted of 61 searchable texts. In 2000,  85 additional texts, transcribed from modern editions, were produced  thanks to a generous grant from the Gladys Krieble Delmas Foundation, many of them among the largest and most significant monuments of Middle English, including the Wycliffite Bible, both versions of Higden's Polychronicon, Cursor Mundi, both versions of Guy of Warwick, the chronicles of Robert Mannyng and Robert of Gloucester, two versions of Mandeville's travels, Hoccleve's Regiment of Princes, the A, B, and C texts of Piers Plowman, the Pricke of Conscience, the Ormulum, and numerous saints' legends, including the Laud MS of the South English Legendary. The texts added in 2000 also included the complete Chaucer Society '6-text' edition of the Canterbury Tales. For the 2018 revision, we have added both large canonical texts (6 Chaucer Society transcripts of individual manuscripts of Chaucer's Troilus), and a host of smaller texts, many in underrepresented genres: a total of 144 new texts, including recipes, account rolls, romances, sermons, legends, inventories, inventories, chronicles, proverbs, and Wycliffite tracts. The new Corpus, though still not a balanced selection of Middle English, is much more representative of the extant literature than it was. And it will continue to welcome new submissions that meet its primary criteria: accuracy, relevance, and freedom from copyright entanglements.</p>
+
+      <hr>
+
+      <h2 id="acknowledgements">Acknowledgments</h2>
+      <h3>Ongoing support</h3>
+      <p>The MEC is maintained by the staff and with the support of the University of Michigan Library.</p>
+      <h3>2018 Revision</h3>
+      <p>Revision of the MEC was funded in part by a two-year grant (2016-18) awarded under the Humanities Collections and Reference Resources program of the National Endowment for the Humanities, matched by funds from the University of Michigan Library and an MED gift fund.</p>
+      <h3>Digital conversion</h3>
+      <p>The creation of the Compendium in 1997-1998 was funded in part by a grant from the National Endowment for the Humanities, with support also provided by the University of Michigan Library and the University of Michigan Press. The keying of ME texts for the Corpus in 2000 was funded by a generous grant from the Gladys Krieble Delmas Foundation.</p>
+      <h3>The MED project</h3>
+      <p>The 70-year Middle English Dictionary project drew on support from (and probably exhausted the patience of) many agencies and individuals over that span, both internal and external, to an extent that can only be hinted at here. The very earliest stages were sponsored by the Modern Language Association and funded by the Heckscher Foundation at Cornell University. Supporters at the University of Michigan (from 1930 on) included the Horace H. Rackham Foundation, the Office of the Vice President for Research, and the Department of English. External supporters included the Rockefeller Foundation (early on, via the American Council of Learned Societies); the Andrew Mellon Foundation (three large grants); the National Endowment for the Humanities (no less than six grants); and a group of individual scholars known as the Friends of the MED, with substantial seed money given generously by Richard Diebold. Contributions in kind included quotation slips and other Middle English materials donated by the heirs of Prof. Ewald Fl&#x00FC;gel, and the 430,000 Middle English quotation slips collected for the OED and transferred by Oxford University Press to the University of Michigan in bulk. Most recently, OED and MED have agreed on a regular data exchange, each having access to an updated digital copy of the other's work in its entirety.
+      <hr>
+
+      <h2 id="notes">Notes</h2>
+      <p id="note1"><sup>1</sup> Review of the <i>Plan and Bibliography</i> by Michael Adams, <i>Dictionaries: Journal of the Dictionary Society of North America</i> 29 (2008), 66.</p>
+      <p id="note2"><sup>2</sup> The few exceptions are noted in the statement of availability attached to each work.</p>
+
+
+
+
 
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,11 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  en:
+    views:
+      static:
+        about-med:
+          title: TEST
   hello: "Hello world"
   lang:
     OE: Old English
@@ -58,10 +63,10 @@ en:
         zoom_out: '<span class="hidden-xs hidden-sm">Zoom Out </span>'
         search_highlights: '<span class="hidden-xs">Search <span class="hidden-sm">Keyword </span></span>Highlights'
     static:
-      about_med:
+      about-med:
         title: About the Middle English Compendium
         header: Middle English About
-      help_med:
+      help-med:
         title: Help in using the Middle English Dictionary
         header: Middle English Help
       about-daily:


### PR DESCRIPTION
A suite of more-or-less minor changes to the actual
words used and what's linked.

  * Add new "About page" with internal navigation
  * Remove links to corpus from all navigation and splash
    pages except in the footer
  * Add blub text for bib and quotation
  * Change "senses on" to "senses in"
  * Make home/splash page headings links
  * Fix links in left column of footer