### PR TITLE
Fix quotation display

### DIFF
--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -18,9 +18,9 @@
       <% if doc_presenter.senses.size > 0 %>
         <div class="quotations-header-options">
           <span class="quotations-header-options-text">Quotations:</span>
-          <a class="show-all-button" href="#" onClick="$('.eg').show(); return false;">Show
+          <a class="show-all-button" href="#" onClick="$('.egs').show(); $('.quote-toggle.open').hide(); $('.quote-toggle.closer').show();return false;">Show
             all</a>
-          <a class="hide-all-button" href="#" onClick="$('.eg').hide();return false">Hide
+          <a class="hide-all-button" href="#" onClick="$('.egs').hide(); $('.quote-toggle.open').show(); $('.quote-toggle.closer').hide(); return false">Hide
             all</a>
         </div>
       <% end %>
@@ -71,7 +71,7 @@
   <%# Get get senses plus their quotes and display %>
   <% unless doc_presenter.senses.size == 0 %>
     <div class="senses">
-      <div class="entry-senses-title">Senses and Subsenses</div>
+      <h3 class="entry-senses-title">Senses and Subsenses</h3>
 
       <% doc_presenter.senses.each_with_index do |sense, index| %>
         <%= render "catalog/show_entry/sense.html.erb", sense: sense, index: index, presenter: doc_presenter %>

--- a/app/views/catalog/show_entry/_sense.html.erb
+++ b/app/views/catalog/show_entry/_sense.html.erb
@@ -22,15 +22,16 @@
       <div class="definition"><%== presenter.def_html(sense) %>
 
       <div class="quote-toggles">
-        <a class="quote-toggle <%= uid %>" href="#" onClick="$('.<%= uid%>').toggle(); return false">Show&nbsp;<%= num_citations %>&nbsp;<%= "Quote".pluralize(num_citations) %></a>
-        <a class="quote-toggle  <%= uid %> collapsed" href="#" onClick="$('.<%= uid%>').toggle(); return false">Hide&nbsp;<%= num_citations %>&nbsp;<%= "Quote".pluralize(num_citations) %></a>
+        <a class="quote-toggle <%= uid %> open" href="#" onClick="$('.<%= uid%>').toggle(); return false">Show&nbsp;<%= num_citations %>&nbsp;<%= "Quotation".pluralize(num_citations) %></a>
+        <a class="quote-toggle  <%= uid %> closer collapsed" href="#" onClick="$('.<%= uid%>').toggle(); return false">Hide&nbsp;<%= num_citations %>&nbsp;<%= "Quotation".pluralize(num_citations) %></a>
       </div>
     </div>
   </div>
 
-  <div class="egs">
+  <div class="egs collapsed <%= uid %>">
+    <h4>Associated quotations</h4>
     <% sense.egs.each do |eg| %>
-      <div class="eg collapsed <%= uid %>">
+      <div class="eg">
         <% if eg.subdef_entry and eg.subdef_entry =~ /\S/ %>
           <div class="subdef-entry-number"><%= eg.subdef_entry %></div>
         <% end %>

--- a/app/views/quotes/_index_header_quote.html.erb
+++ b/app/views/quotes/_index_header_quote.html.erb
@@ -10,9 +10,9 @@
     font-size: 14px
   }
 
-    span.pos {
-      font-style: italic;
-    }
+  span.pos {
+    font-style: italic;
+  }
 
 </style>
 
@@ -43,11 +43,16 @@
       <div class="search-result def">
 
         <div class="definition-block">
-          <div class="def-header">Associated bib entry</div>
+          <div class="def-header">Associated bibliographic data</div>
           <div class="definition">
-            <a href="bibliography/<%= document.fetch('bib_id') %>">
+            <% if document.has_key?('bib_id') %>
+              <a href="bibliography/<%= document.fetch('bib_id') %>">
+                <%== doc_presenter.citation_link_text %>
+              </a>
+            <% else %>
               <%== doc_presenter.citation_link_text %>
-            </a>
+            <% end %>
+
           </div>
         </div>
 

--- a/indexer/xslt/_CitOnly.xsl
+++ b/indexer/xslt/_CitOnly.xsl
@@ -47,7 +47,7 @@
   <xsl:template match="Q">
     <span class="Q">
       <xsl:value-of select="."/>
-      <xsl:text></xsl:text>
+      <xsl:text> </xsl:text>
     </span>
   </xsl:template>
 


### PR DESCRIPTION
  * Quotations whose citation isn't in the bibliography now display
    without throwing an error
  * Change quote show/hide logic a bit so "Show all" and "Hide all"
    maintain consistent show/hide buttons for the individual senses.