### PR TITLE
Index stencils by pieces to avoid running text together

### DIFF
--- a/indexer/bib_indexing_rules.rb
+++ b/indexer/bib_indexing_rules.rb
@@ -131,7 +131,9 @@ end
 to_field 'stencil_keyword' do |bib, acc, context|
   node = context.clipboard[:nokonode]
   node.xpath('//STENCIL|//SHORTSTENCIL').each do |n|
-    acc << n.text
+    n.children.each do |child|
+      acc << child.text
+    end
   end
 end
 

--- a/solr/med/core.properties
+++ b/solr/med/core.properties
@@ -1,1 +1,0 @@
-name=med


### PR DESCRIPTION
This address the problem of not being able to search for "Cmb.Hom" in bib. 

Problem was that I was just getthing the xml text, and had something like `<A>Cmb.Hom.</><B>Hom</B>`, so it was being indexed as a single token "Cmb.Hom.Hom".