### PR TITLE
Add utility methods to do maintenance_mode route.

### DIFF
--- a/app/views/static/maintenance_mode.html.erb
+++ b/app/views/static/maintenance_mode.html.erb
@@ -1,0 +1,18 @@
+<% @page_title = 'Middle English Dictionary is down for maintenance' %>
+
+<div class="container help-container">
+  <div>
+    <div id="med" class="<%= main_content_classes %> about-middle-col">
+
+      <h1 id="down">The MED is temporarily unavailable</h1>
+
+
+      <p>The Middle English Dictionary has been temporarily taken offline in
+        order to perform
+        maintenance and apply updates. It should be back up within an hour.
+      </p>
+
+
+    </div>
+  </div>
+</div>

--- a/bin/dromedary
+++ b/bin/dromedary
@@ -48,9 +48,11 @@ MedInstaller::CLI.register 'remote deploy', MedInstaller::Remote::Deploy
 MedInstaller::CLI.register 'remote restart', MedInstaller::Remote::Restart
 MedInstaller::CLI.register 'remote dromedary', MedInstaller::Remote::Dromedary
 MedInstaller::CLI.register 'remote exec', MedInstaller::Remote::Exec
-MedInstaller::CLI.register 'remote maintenance_mode', MedInstaller::Remote::MaintenanceMode
 
 
+# Maintenance mode
+MedInstaller::CLI.register 'maintenance_mode on', MedInstaller::Control::MaintenanceModeOn
+MedInstaller::CLI.register 'maintenance_mode off', MedInstaller::Control::MaintenanceModeOff
 
 # Solr utilities for your development environment.
 MedInstaller::CLI.register 'solr install', MedInstaller::Solr::Install

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,14 @@
+require 'annoying_utilities'
+
 Rails.application.routes.draw do
 
   scope Dromedary.config.relative_url_root do
 
     mount Blacklight::Engine => Dromedary.config.relative_url_root
+
+    # Shunt it all to the maintenace page if we need to
+    match '*path' => 'static#maintenance_mode', status: 302, via: [:get, :post],
+          constraints: ->(request) { AnnoyingUtilities.maintenance_mode_enabled? }
 
 
     # Splash pages

--- a/lib/annoying_utilities.rb
+++ b/lib/annoying_utilities.rb
@@ -13,12 +13,22 @@ module AnnoyingUtilities
   DEFAULT_SOLR   = DROMEDARY_ROOT.parent + 'solr'
   CONFIG_DIR     = DROMEDARY_ROOT + 'config'
 
+
+
   extend MedInstaller::Logger
 
   extend self
 
   def data_dir
     Pathname.new(Dromedary.config.data_dir)
+  end
+
+  def maintenance_mode_flag_file
+    data_dir + 'MAINTENANCE_MODE_ENABLED'
+  end
+
+  def maintenance_mode_enabled?
+    File.exist? maintenance_mode_flag_file
   end
 
   def bibfile_path

--- a/lib/med_installer.rb
+++ b/lib/med_installer.rb
@@ -12,4 +12,5 @@ require_relative 'med_installer/indexer/bib_reader'
 require_relative 'med_installer/index'
 
 require_relative 'med_installer/remote'
+require_relative 'med_installer/control'
 

--- a/lib/med_installer/control.rb
+++ b/lib/med_installer/control.rb
@@ -1,0 +1,31 @@
+require 'hanami/cli'
+require 'annoying_utilities'
+require_relative "logger"
+
+module MedInstaller
+  class Control
+    extend MedInstaller::Logger
+
+    class MaintenanceModeOn < Hanami::CLI::Command
+      desc "Turn on maintenance mode (redirect all pages to temp down page)"
+
+      def call(command)
+        File.open AnnoyingUtilities.maintenance_mode_flag_file, 'w:utf-8' do |f|
+          f.puts "To take out of maintenance mode, remove this file manually
+                or by running `bin/dromedary maintenance_mode off`"
+        end
+      end
+    end
+
+    class MaintenanceModeOff < Hanami::CLI::Command
+      desc "Turn off maintenance mode (redirect all pages to temp down page)"
+
+      def call(command)
+        FileUtils.remove_file(AnnoyingUtilities.maintenance_mode_flag_file, :force)
+      end
+    end
+  end
+end
+
+
+

--- a/lib/med_installer/remote.rb
+++ b/lib/med_installer/remote.rb
@@ -81,24 +81,5 @@ module MedInstaller
       end
     end
 
-    class MaintenanceMode < Hanami::CLI::Command
-      include MedInstaller::Logger
-
-
-      MAINTENANCE_MODE_TAG = "KEEP_maintenance_mode"
-
-
-      desc "Put the given remote into maintenance mode"
-      argument :target, required: true, desc: "Which deployment (testing/staging/production)"
-
-      def call(target:)
-        target = Remote.validate_target!(target)
-        sleep(Remote::PANIC_PAUSE)
-        logger.info "Putting #{target.upcase} into maintenance mode by checking out tag '#{MAINTENANCE_MODE_TAG}'"
-        system "ssh deployhost deploy -v dromedary-#{target} #{MAINTENANCE_MODE_TAG}"
-      end
-
-    end
-
   end
 end


### PR DESCRIPTION
Fixes maintenance mode to use a flag file, so as to not get
MM branch out of date. New dromedary commands

  * bin/dromedary maintenance_mode on
  * bin/dromedary maintenance_mode off

Can be run on remote install with

  * bin/dromedary remote dromedary staging "maintenance_mode off"