### PR TITLE
Indexing changes: author.title, manuscript, k->c

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 # When developing in tandem, a relative path is nice and easy
 
 # gem 'middle_english_dictionary', path: "/Users/dueberb/devel/med/middle_english_dictionary"
-gem 'middle_english_dictionary', '~>1.5.0'
+gem 'middle_english_dictionary', '~>1.6.0'
 
 
 # Use Ettin for configuration

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
     marc-fastxmlwriter (1.0.0)
       marc (~> 1.0)
     method_source (0.9.0)
-    middle_english_dictionary (1.5.0)
+    middle_english_dictionary (1.6.0)
       multi_json
       nokogiri (~> 1.6)
       representable
@@ -350,7 +350,7 @@ DEPENDENCIES
   listen
   lograge
   mail_form (= 1.7.0)
-  middle_english_dictionary (~> 1.5.0)
+  middle_english_dictionary (~> 1.6.0)
   mysql2 (< 0.5.0)
   nestive (= 0.6.0)
   nokogiri

--- a/indexer/bib_indexing_rules.rb
+++ b/indexer/bib_indexing_rules.rb
@@ -19,9 +19,9 @@ Traject::Indexer.send(:define_method, :logger, ->() {AnnoyingUtilities.logger})
 
 def bib_method(name)
   ->(rec, acc) do
-      values = Array(rec.send(name)).compact
-      acc.replace(values) unless values.empty?
-    end
+    values = Array(rec.send(name)).compact
+    acc.replace(values) unless values.empty?
+  end
 end
 
 def remove_leading_articles(str)
@@ -70,19 +70,25 @@ to_field 'title_sort' do |bib, acc|
   acc << title
 end
 
+to_field 'authortitle' do |bib, acc|
+  if bib.author
+    acc << [bib.author, bib.title_text].compact.join('.')
+  end
+end
+
 to_field 'incipit' do |bib, acc|
   acc << bib.incipit?.to_s
 end
 
 # External references
 
-to_field 'index',    bib_method(:indexes)
-to_field 'indexb',   bib_method(:indexbs)
-to_field 'indexc',   bib_method(:indexcs)
-to_field 'ipmep',    bib_method(:ipmeps)
+to_field 'index', bib_method(:indexes)
+to_field 'indexb', bib_method(:indexbs)
+to_field 'indexc', bib_method(:indexcs)
+to_field 'ipmep', bib_method(:ipmeps)
 to_field 'jolliffe', bib_method(:jolliffes)
-to_field 'severs',   bib_method(:severs)
-to_field 'wells',    bib_method(:wells)
+to_field 'severs', bib_method(:severs)
+to_field 'wells', bib_method(:wells)
 
 # LALME
 to_field 'lalme' do |bib, acc|

--- a/indexer/main_indexing_rules.rb
+++ b/indexer/main_indexing_rules.rb
@@ -129,6 +129,16 @@ to_field('min_cd') do |entry, acc|
   acc << entry.all_citations.flat_map(&:cd).compact.min
 end
 
+# Author.Title
+# We special-case this 'cause people want to search on, e.g.,
+# Capgr.Chron. The '.' is *not* a breaking charactor for the
+# me_text or text data types, so we can just use one
+
+to_field 'authortitle' do |entry, acc|
+  acc.replace entry.all_stencils.map{|s| [s.author, s.title].compact.join('.').gsub(/\.+/, '.').gsub(/\.\Z/, '')}
+end
+
+
 # Notes
 to_field 'notes', entry_method(:notes)
 

--- a/indexer/quote/basic_rules.rb
+++ b/indexer/quote/basic_rules.rb
@@ -18,16 +18,8 @@ end
 
 Traject::Indexer.send(:define_method, :logger, ->() {AnnoyingUtilities.logger})
 
-
-# For quotes, a record is a simple struct
-#   quote: <string>
-#   entry_id: "MED..."
-#   cd: date_of_creation.to_i,
-#   md: date_of_manuscript.to_i
-#   quote_html: html of the quote <string>,
-#   rid: rid for this stencil
-#   title: title of the stencil
-#   manuscript: manuscript abbreviation thing
+# Note that even though we're talking about quotations, the object
+# we're dealing with is an IndexableQuote (lib/serialization/indexable_quote.rb)
 
 def lazy_method(name)
   ->(rec, acc) {acc.replace Array(rec.send(name))}
@@ -81,6 +73,12 @@ end
 
 to_field 'bib_id', lazy_method(:bib_id)
 to_field 'author', lazy_method(:author)
+to_field 'title', lazy_method(:title)
+
+to_field 'authortitle' do |q, acc|
+    acc << [q.stencil_author, q.stencil_title].compact.join('.').gsub(/\.+/, '.').gsub(/\.\Z/, '')
+  end
+
 
 # def initialize(citation: citation)
 #   self.quote      = citation.quote.text

--- a/lib/med_installer/index.rb
+++ b/lib/med_installer/index.rb
@@ -121,8 +121,13 @@ module MedInstaller
         HypToBibID.new(command_name: "hyp_to_bib_id").call
         raise "Solr at #{AnnoyingUtilities.blacklight_solr_url} not up" unless AnnoyingUtilities.solr_core.up?
         writer = select_writer(debug)
-        fields = indexing_rules_file
-        index(rulesfile: fields, datafile: AnnoyingUtilities.bibfile_path, writer: writer, bibfile: AnnoyingUtilities.bibfile_path)
+        index(rulesfile: index_dir + 'bib_indexing_rules.rb',
+              datafile:  AnnoyingUtilities.bibfile_path,
+              writer:    writer,
+              bibfile:   AnnoyingUtilities.bibfile_path)
+        commit
+        optimize
+        commit
       end
     end
 

--- a/lib/med_installer/indexer/entry_json_reader.rb
+++ b/lib/med_installer/indexer/entry_json_reader.rb
@@ -55,6 +55,7 @@ module MedInstaller
 
     def each
       Zlib::GzipReader.new(File.open(@data_file)).each_with_index do |json_line, index|
+        next unless json_line =~ /\S/
         begin
           entry = MiddleEnglishDictionary::Entry.from_json(depipe_json(json_line))
           yield entry

--- a/lib/serialization/indexable_quote.rb
+++ b/lib/serialization/indexable_quote.rb
@@ -23,7 +23,8 @@ module Dromedary
                   :cd, :md,
                   :scope, :rid, :title, :ms,
                   :citation,
-                  :bib_id, :author,
+                  :author, :title,
+                  :bib_id, :stencil_author, :stencil_title,
                   :dubious
 
     alias_method :med_id, :entry_id
@@ -41,6 +42,9 @@ module Dromedary
       self.rid      = stencil.rid
       self.date     = stencil.date
       self.title    = stencil.title
+      self.author   = stencil.author
+      self.stencil_title = stencil.title
+      self.stencil_author = stencil.author
       self.ms       = stencil.ms
       self.citation = citation
       self.text = citation.text

--- a/solr/med/conf/schema.xml
+++ b/solr/med/conf/schema.xml
@@ -192,17 +192,17 @@
 
 
   <!--Headwords and orths-->
-  <field name="official_headword" type="me_text" indexed="true" stored="true" multiValued="true"/>
-  <field name="official_headword_exactish" type="me_exactish" indexed="true" stored="false" multiValued="true"/>
+  <field name="official_headword" type="me_headword" indexed="true" stored="true" multiValued="true"/>
+  <field name="official_headword_exactish" type="me_headword_exactish" indexed="true" stored="false" multiValued="true"/>
   <copyField source="official_headword" dest="official_headword_exactish"/>
 
-  <field name="headword"     type="me_text" indexed="true" stored="true" multiValued="true"/>
-  <field name="headword_exactish" type="me_exactish" indexed="true" stored="true" multiValued="true"/>
+  <field name="headword"     type="me_headword" indexed="true" stored="true" multiValued="true"/>
+  <field name="headword_exactish" type="me_headword_exactish" indexed="true" stored="true" multiValued="true"/>
   <copyField source="headword" dest="headword_exactish"/>
 
   <field name="dubious" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
 
-  <field name="orth"         type="me_text" indexed="true" stored="true" multiValued="true"/>
+  <field name="orth"         type="me_headword" indexed="true" stored="true" multiValued="true"/>
 
   <!--Etymology and Part of speach-->
   <field name="pos"        type="string"  stored="true" indexed="true" multiValued="true" docValues="true"/>
@@ -225,6 +225,9 @@
   <!-- Quotes -->
   <field name="quote_text"  type="me_text" indexed="true" stored="true" multiValued="true"/>
   <field name="quote_title" type="me_text" indexed="true" stored="true" multiValued="true"/>
+
+  <!-- The quote author and title are sometimes jammed together with a '.' between. -->
+  <field name="authortitle" type="me_text" indexed="true" stored="true" multiValued="true"/>
 
   <field name="quote_manuscript" type="text" indexed="true" stored="true" multiValued="true"/>
   <field name="quote_date" type="string" indexed="false" stored="true" multiValued="true"/>
@@ -276,8 +279,8 @@
   <copyField source="author" dest="author_exactish"/>
 
 
-  <field name="title" type="me_text" stored="true" indexed="true" multiValued="false"/>
-  <field name="title_sort" type="me_sort" stored="true" indexed="true" multiValued="false"/>
+  <field name="title" type="me_text" stored="true" indexed="true" multiValued="true"/>
+  <field name="title_sort" type="me_sort" stored="true" indexed="true" multiValued="true"/>
 
   <field name="title_exactish" type="me_exactish" stored="false" indexed="true" multiValued="true"/>
   <copyField source="title" dest="title_exactish"/>
@@ -322,3 +325,4 @@
 
 
 </schema>
+

--- a/solr/med/conf/schema/middle_english_char_substitution_patterns.xml
+++ b/solr/med/conf/schema/middle_english_char_substitution_patterns.xml
@@ -15,12 +15,8 @@ Spelling wasn't so much a "thing" for ME, so we'll do some messing around
 />
 
 
-
-
-<!--Ditch any parentheses and crap in the headwords -->
-<!--to avoid problems with tokenization-->
-
 <charFilter class="solr.PatternReplaceCharFilterFactory"
-            pattern="[()!?.;]" replacement=""
+            pattern="[k]" replacement="c"
 />
+
 

--- a/solr/med/conf/schema/middle_english_types.xml
+++ b/solr/med/conf/schema/middle_english_types.xml
@@ -2,20 +2,60 @@
 
 <fieldType name="me_text" class="solr.TextField"
            positionIncrementGap="&tpig;">
-  <analyzer type="index">
-    &me_text_chain;
-    <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-  </analyzer>
-  <analyzer type="query">
+  <analyzer>
     &me_text_chain;
     <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
   </analyzer>
 </fieldType>
 
+<!-- For headwords, we also want to eliminate interstitial punctuation -->
+
+<fieldType name="me_headword" class="solr.TextField"
+           positionIncrementGap="&tpig;">
+<analyzer>
+  <!--Ditch any parentheses and crap in the headwords -->
+  <!--to avoid problems with tokenization-->
+  <charFilter class="solr.PatternReplaceCharFilterFactory"
+              pattern="[()!?.;]" replacement=""
+  />
+  &me_text_chain;
+  <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+</analyzer>
+</fieldType>
+
+
+
         <!-- An exactish search, but for middle english text -->
 <fieldType name="me_exactish" class="solr.TextField"
            positionIncrementGap="&tpig;">
 <analyzer>
+  &middle_english_char_substitution_patterns;
+  <charFilter class="solr.ICUNormalizer2CharFilterFactory"/>
+  <tokenizer class="solr.KeywordTokenizerFactory"/>
+  <filter class="solr.ICUFoldingFilterFactory"/>
+  <filter class="solr.KeywordRepeatFilterFactory"/>
+  <!-- Some punctuation that should be turned into a space (probably just - and |). -->
+  <filter class="solr.PatternReplaceFilterFactory"
+          pattern="([\-\|])" replacement=" " replace="all"
+  />
+
+  <!-- Remove all other punctuation at the end of teh string -->
+  <filter class="solr.PatternReplaceFilterFactory"
+          pattern="(\p{Punct}$)" replacement="" replace="all"
+  />
+  <filter class="solr.TrimFilterFactory"/>
+  <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+</analyzer>
+</fieldType>
+
+
+        <!-- An exactish search for headwords  -->
+<fieldType name="me_headword_exactish" class="solr.TextField"
+           positionIncrementGap="&tpig;">
+<analyzer>
+  <charFilter class="solr.PatternReplaceCharFilterFactory"
+              pattern="[()!?.;]" replacement=""
+  />
   &middle_english_char_substitution_patterns;
   <charFilter class="solr.ICUNormalizer2CharFilterFactory"/>
   <tokenizer class="solr.KeywordTokenizerFactory"/>

--- a/solr/med/conf/solrconfig_med/bib_searches/author_title_search.xml
+++ b/solr/med/conf/solrconfig_med/bib_searches/author_title_search.xml
@@ -1,4 +1,5 @@
 <str name="bib_author_title_qf">
+  authortitle^6
   author_exactish^4
   author^3
   title_exactish^2
@@ -6,6 +7,7 @@
 </str>
 
 <str name="bib_author_title_pf">
+  authortitle^6
   author^2
   title^1
 </str>

--- a/solr/med/conf/solrconfig_med/bib_searches/everything_search.xml
+++ b/solr/med/conf/solrconfig_med/bib_searches/everything_search.xml
@@ -1,4 +1,5 @@
 <str name="bib_everything_qf">
+  authortitle^6
   author_exactish^6
   title_exactish^5
   author^4
@@ -9,6 +10,7 @@
 </str>
 
 <str name="bib_everything_pf">
+  authortitle^6
   author^5
   title^3
   stencil_keyword^2

--- a/solr/med/conf/solrconfig_med/bib_searches/stencil_search.xml
+++ b/solr/med/conf/solrconfig_med/bib_searches/stencil_search.xml
@@ -1,7 +1,9 @@
 <str name="bib_stencil_qf">
+  authortitle
   stencil_keyword
 </str>
 
 <str name="bib_stencil_pf">
+  authortitle
   stencil_keyword
 </str>

--- a/solr/med/conf/solrconfig_med/entry_searches/citation_search.xml
+++ b/solr/med/conf/solrconfig_med/entry_searches/citation_search.xml
@@ -1,9 +1,13 @@
 <str name="citation_qf">
   quote_text^10
+  authortitle^6
   citation_text
+  quote_manuscript
 </str>
 
 <str name="citation_pf">
   quote_text^10
+  authortitle^6
   citation_text
+  quote_manuscript
 </str>

--- a/solr/med/conf/solrconfig_med/entry_searches/everything_search.xml
+++ b/solr/med/conf/solrconfig_med/entry_searches/everything_search.xml
@@ -3,9 +3,11 @@
   headword_exactish^50
   headword^10
   orth^7
+  authortitle^6
   definition_text^5
   oed_norm^2
   keyword
+  quote_manuscript
 </str>
 
 <str name="everything_pf">
@@ -13,8 +15,11 @@
   headword_exactish^50
   headword^10
   orth^7
+  authortitle^6
   definition_text^5
   oed_norm^2
+  quote_manuscript
   keyword
+
 </str>
 

--- a/solr/med/conf/solrconfig_med/quote_searches/quote_everything_search.xml
+++ b/solr/med/conf/solrconfig_med/quote_searches/quote_everything_search.xml
@@ -1,9 +1,14 @@
 <str name="quote_everything_qf">
+  authortitle^6
   quote_text^2
+  headword
+  quote_manuscript
   keyword
 </str>
 
 <str name="quote_everything_pf">
+  authortitle^6
   quote_text^2
+  quote_manuscript
   keyword
 </str>


### PR DESCRIPTION
Researchers want to be able to search author.title
(e.g., Capgr.Chron) to find particular authors
and manuscripts. This indexing change does this
through two changes:

  * Change solr config so that dots are removed
    only for headwords
  * Add indexing of author.title

These changes are predicated on using the gem
middle_english_dictionary v. 1.6.0 or later,
since the stencil author was inadventantly
left out in the past.

Also:
  * Add quote_manuscript to entry/quotation searches
    so "LdMisc 108" gives expected results
  * Do a mapping from k->c on index and query