### PR TITLE
Prefix suffix

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -2,7 +2,10 @@
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
 
-  self.default_processor_chain += [:yogh_to_ezh, :escape_intersticial_parens, :default_to_everything_search]
+  self.default_processor_chain += [:yogh_to_ezh,
+                                   :escape_intersticial_parens,
+                                   :escape_prefix_suffix_dash,
+                                   :default_to_everything_search]
 
 
   # q"=>"{!qf=$quote_everything_qf pf=$quote_everything_pf}right",
@@ -12,7 +15,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   #
   # This might be a problem with the advanced search...
 
-  EscapeWorthy = /([-\p{Alpha}])\((\p{Alpha}{1,3})\)/
+  Parens_EscapeWorthy = /([-\p{Alpha}])\((\p{Alpha}{1,3})\)/
 
 
   # TODO: Get these values from blacklight_config
@@ -22,17 +25,41 @@ class SearchBuilder < Blacklight::SearchBuilder
      'quotes' => 'quote_date_sort asc, author_sort asc'
   }
 
+
+  # These two characters are equivalent
   def yogh_to_ezh(solr_params)
     solr_params['q'] = solr_params['q'].gsub(/[Ȝȝ]/, 'ʒ')
   end
 
+  # Sometimes, you gotta escape the parens so things parse right
   def escape_intersticial_parens(solr_params)
     current_q = solr_params['q']
     if current_q
-      new_q            = current_q.gsub EscapeWorthy, '\1\\\\(\2\\\\)'
+      new_q            = current_q.gsub Parens_EscapeWorthy, '\1\\\\(\2\\\\)'
       solr_params['q'] = new_q
       solr_params['debug'] = 'true'
     end
+  end
+
+  # There are prefixes and suffixes in the dictionary -- we want to
+  # escape the leading- or trailing- dashes
+  #
+  # This will also have the effect of making '-' no longer work
+  # as a unary NOT operator.
+  #
+  # Note that the solr query is generated as something like
+  # {!qf=$headword_and_forms_qf pf=$headword_and_forms_pf}-ward
+  # ...so the beginning of the prefix actually follows a '}'
+
+  def escape_prefix_suffix_dash(solr_params)
+    q = solr_params['q']
+    oq = q
+    q = q.gsub(/\}\-/, '}\\\\-')
+    q = q.gsub(/\s+-/, ' \\\\-')
+    q = q.gsub(/\-\s+/, '\\\\- ')
+    q = q.gsub(/\-\Z/, '\\\\-')
+    solr_params['q'] = q
+    File.open('dash.txt', 'w:utf-8') {|f| f.puts "#{oq}\n#{q}"}
   end
 
   def default_to_everything_search(solr_params)

--- a/app/presenters/dromedary/index_presenter.rb
+++ b/app/presenters/dromedary/index_presenter.rb
@@ -58,6 +58,10 @@ module Dromedary
       xsl_transform_from_entry('/ENTRYFREE/ETYM', load_xslt('EtymOnly.xsl'))
     end
 
+    def language_abbreviations
+      entry.etym_languages
+    end
+
 
     # @param [MiddleEnglishDictionary::Entry::Sense,MiddleEnglishDictionary::Entry::SenseGrp] sense The sense whose def you want
     # @return [SmartXML, nil] The definition transformed into HTML, or nil

--- a/app/views/catalog/show_entry/_sensegrp.html.erb
+++ b/app/views/catalog/show_entry/_sensegrp.html.erb
@@ -3,7 +3,7 @@
 
 <div class="sense sensegrp">
   <div class="entry-senses sensegrp-line">
-    <div class="sense-number"><%= sensegrp.sensegrp_number %>.</div>
+    <div class="sense-number"><%= sensegrp.sensegrp_number.nil? ? '' : "#{sensegrp.sensegrp_number}." %></div>
     <div class="definition"><%== presenter.def_html(sensegrp) %></div>
   </div>
 

--- a/app/views/static/about_med.html.erb
+++ b/app/views/static/about_med.html.erb
@@ -366,6 +366,16 @@
       <p>The MEC is maintained by the staff and with the support of the
         University of Michigan Library.</p>
 
+      <p>Current staff: Paul Schaffner (managing editor);
+        John Latta and Mona Logarbo (editors);
+        Robert E. Lewis (MED chief editor emeritus; volunteer editor);
+        Evan David, Sarah Huttenlocher, and Alyssa Pierce (editorial assistants);
+        Chris Powell (retrieval specialist);
+        Bill Dueber, Gordon Leacock, and Tom Burton-West (programmers);
+        Ben Howell (interface designer);
+        Bridget Burke (interface developer);
+        and Nabeela Jaffer (implementation project manager)</p>
+      <p>... building on the work of innumerable predecessors.</p>
       <h3>2018 Revision</h3>
 
       <p>Revision of the MEC was funded in part by a two-year grant (2016-18)

--- a/indexer/main_indexing_rules.rb
+++ b/indexer/main_indexing_rules.rb
@@ -55,6 +55,18 @@ end
 to_field 'headword', entry_method(:regularized_headwords)
 to_field 'orth', entry_method(:all_regularized_forms)
 
+# suffixes and prefixes
+# So, we also want to prefer a suffix or prefix (start or ending
+# with a dash) on a headword, so we'll send it up again with
+# the dash escaped.
+
+to_field 'prefix_suffix' do |entry, acc|
+  entry.regularized_headwords.each do |hw|
+    if hw =~ /\A\-/ or hw =~ /\-\Z/
+      acc << hw
+    end
+  end
+end
 
 # Dubious entry?
 each_record do |entry, context|

--- a/solr/med/conf/schema.xml
+++ b/solr/med/conf/schema.xml
@@ -196,6 +196,10 @@
   <field name="headword_exactish" type="me_headword_exactish" indexed="true" stored="true" multiValued="true"/>
   <copyField source="headword" dest="headword_exactish"/>
 
+  <!-- special-case prefix/suffix, escaping the leading or trailing dash -->
+  <field name="prefix_suffix" type="me_prefix_suffix" indexed="true" stored="true" multiValued="true"/>
+
+
   <field name="dubious" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
 
   <field name="orth"         type="me_headword" indexed="true" stored="true" multiValued="true"/>

--- a/solr/med/conf/schema/middle_english_types.xml
+++ b/solr/med/conf/schema/middle_english_types.xml
@@ -98,6 +98,21 @@
 </analyzer>
 </fieldType>
 
+<!-- An exactish headword, but preserve leading- and trailing- dashes -->
+<fieldType name="me_prefix_suffix" class="solr.TextField" positionIncrementGap="&tpig;">
+  &middle_english_char_substitution_patterns;
+  <charFilter class="solr.ICUNormalizer2CharFilterFactory"/>
+  <tokenizer class="solr.KeywordTokenizerFactory"/>
+  <filter class="solr.ICUFoldingFilterFactory"/>
+  <filter class="solr.KeywordRepeatFilterFactory"/>
+  <!-- Some punctuation that should be turned into a space (just |). -->
+  <filter class="solr.PatternReplaceFilterFactory"
+          pattern="([\|])" replacement=" " replace="all"
+  />
+  <filter class="solr.TrimFilterFactory"/>
+</fieldType>
+
+
 
 
 <fieldType name="me_sort" class="solr.TextField"

--- a/solr/med/conf/solrconfig_med/entry_searches/everything_search.xml
+++ b/solr/med/conf/solrconfig_med/entry_searches/everything_search.xml
@@ -1,4 +1,5 @@
 <str name="everything_qf">
+  prefix_suffix^90
   headword_exactish^50
   headword^10
   orth^7
@@ -10,6 +11,7 @@
 </str>
 
 <str name="everything_pf">
+  prefix_suffix^90
   headword_exactish^50
   headword^10
   orth^7

--- a/solr/med/conf/solrconfig_med/entry_searches/headword_and_forms_search.xml
+++ b/solr/med/conf/solrconfig_med/entry_searches/headword_and_forms_search.xml
@@ -1,10 +1,12 @@
 <str name="headword_and_forms_qf">
+  prefix_suffix^90
   headword_exactish^50
   headword^10
   orth^1
 </str>
 
 <str name="headword_and_forms_pf">
+prefix_suffix^90
 headword_exactish^50
 headword^10
 orth^1

--- a/solr/med/conf/solrconfig_med/entry_searches/headword_only_search.xml
+++ b/solr/med/conf/solrconfig_med/entry_searches/headword_only_search.xml
@@ -1,9 +1,11 @@
 <str name="headword_only_qf">
+  prefix_suffix^90
   headword_exactish^50
   headword^10
 </str>
 
 <str name="headword_only_pf">
+prefix_suffix^90
 headword_exactish^50
 headword^10
 </str>


### PR DESCRIPTION
Better prefix/suffix handling in searches. 

Argh. Why doesn't it pre-populate with the latest commit message??? Pasting.


Searches for, e.g., `-ward` were incorrectly handled in
two ways:
  * The `-` was interpreted as a unary NOT (part of edismax)
  * The `-` was being thrown away as a junk charactor and/or
    as a word boundary.

This commit does the following:
  * Add a function to the pipline in `search_builder.rb`
    that escapes leading or trailing dashes before they
    get sent up to Solr, to avoid the unary negative
    interpretation.
  * Adds a new fieldType `me_prefix_suffix` that acts like
    an exactish ME field (in terms of latinizing for search)
    but protects a leading- or trailing dash
  * Create a new field, `prefix_suffix` of that type
  * Populate the field with regularized headwords iff
    the headword has a leading or trailing dash
  * Make a search matching the `prefix_suffix` field
    the (currently) most powerful search field.