### PR TITLE
Adds link redirect to fix broken image link

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -3,7 +3,7 @@
 
     <div class="container container--full site-header-container">
       <div class="site-title-container">
-        <a href="<%=root_path %>" class="site-link site-title-flex"><img class="site-logo" src="https://www.lib.umich.edu/falafel/v0/graphics/mlib_square__transparent.svg" alt="University of Michigan"><span class="site-title">Middle English Compendium</span></a>
+        <a href="<%=root_path %>" class="site-link site-title-flex"><img class="site-logo" src="https://apps.lib.umich.edu/falafel/v0/graphics/mlib_square__transparent.svg" alt="University of Michigan"><span class="site-title">Middle English Compendium</span></a>
       </div>
        <button type="button" class="navbar-toggle btn collapsed" data-toggle="collapse" data-target="#user-util-collapse">
       <span class="sr-only">Toggle navigation</span>


### PR DESCRIPTION
The new website launch created a broken image link for the "M" block image across some sites. This commit adds the correct link for the redirect. 

Note: the Design System will be working on creating stable assets in one place to avoid this in the future.