### PR TITLE
Restructure builds to support relative root and CDN

### DIFF
--- a/.github/workflows/build-unstable-branch.yml
+++ b/.github/workflows/build-unstable-branch.yml
@@ -14,17 +14,20 @@ jobs:
           fetch-depth: 0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build image and push to GitHub Container Registry
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true
           tags: 'ghcr.io/mlibrary/dromedary/dromedary-unstable:${{ github.sha }}'
           file: ./Dockerfile
+          target: production
+          build-args:
+            - RAILS_RELATIVE_URL_ROOT=/m/middle-english-dictionary
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.bundle
 /.cache
+/.local
 /data
 /db/*.sqlite3
 /log

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     git \
     unzip \
     libpq-dev \
-    ##### FIXME: remove these once useles gems are trimmed \
+    ##### FIXME: remove these once useless gems are trimmed \
     libmariadb-dev \
     libsqlite3-dev \
     ##### What is netcat here for???
@@ -96,6 +96,8 @@ RUN --mount=type=cache,id=med-bundle-dev,sharing=locked,target=/vendor/bundle \
 #############
 FROM gems-prod AS production
 
+ARG RAILS_RELATIVE_URL_ROOT
+
 COPY . .
 RUN chown -R ${UID}:${GID} /gems && chown -R ${UID}:${GID} /opt/app
 
@@ -103,9 +105,17 @@ RUN chown -R ${UID}:${GID} /gems && chown -R ${UID}:${GID} /opt/app
 EXPOSE 3000
 USER $UNAME
 
-ENV SECRET_KEY_BASE 121222bccca
+### temporarily required to start up/precompile
+ENV SOLR_ROOT=bogus
+ENV SOLR_COLLECTION=bogus
+###
+
 ENV RAILS_ENV production
-RUN RAILS_ENV=production bin/rails assets:precompile
+ENV RAILS_SERVE_STATIC_FILES true
+ENV SECRET_KEY_BASE 121222bccca
+ENV RAILS_RELATIVE_URL_ROOT=${RAILS_RELATIVE_URL_ROOT}
+
+RUN bin/rails assets:precompile
 
 CMD ["bin/rails", "s", "-b", "0.0.0.0"]
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,9 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+# GitHub Packages requires tokens, even for public repositories; so we use git for now
 # source "https://rubygems.pkg.github.com/mlibrary" do
-# gem "middle_english_dictionary", "1.9.0"
+#   gem "middle_english_dictionary", "1.9.1"
 # end
 gem "middle_english_dictionary", git: "https://github.com/mlibrary/middle_english_dictionary", tag: "v1.9.1"
 

--- a/compose.yml
+++ b/compose.yml
@@ -8,7 +8,6 @@ services:
     build:
       dockerfile: Dockerfile
       context: .
-      target: development
       args:
         UID: ${UID:-1000}
         GID: ${GID:-1000}

--- a/compose.yml
+++ b/compose.yml
@@ -8,8 +8,12 @@ services:
     build:
       dockerfile: Dockerfile
       context: .
+      target: development
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
     ports:
-      - "3000:3000" # Rails
+      - "127.0.0.1:3000:3000" # Rails
       - "1111:1111"
       - "1234:1234" # RubyMine
       - "26162:26162" # RubyMine
@@ -21,16 +25,9 @@ services:
       - SOLR_PASSWORD=SolrRocks
       - DATA_ROOT=/mec/data
       - BUILD_ROOT=/mec/data/build
-      - RAILS_ROOT=/m/middle-english-dictionary
     volumes:
       - .:/opt/app
       - data:/mec/data
-      - gems:/opt/app/gems
-    command:
-      - bin/rails
-      - s
-      - -b
-      - 0.0.0.0
 
   db:
     image: postgres:12-alpine
@@ -92,7 +89,6 @@ volumes:
       type: none
       device: ${PWD}/data
       o: bind
-  gems:
   db:
   solr:
     driver_opts:

--- a/config.ru
+++ b/config.ru
@@ -2,8 +2,6 @@
 
 require_relative "config/environment"
 
-run Rails.application
-# this is in the routes now
-# map Dromedary.config.relative_url_root || "/" do
-#   run Rails.application
-# end
+map Dromedary.config.relative_url_root || "/" do
+  run Rails.application
+end

--- a/config.ru
+++ b/config.ru
@@ -2,7 +2,6 @@
 
 require_relative "config/environment"
 
-run Rails.application
-# map Dromedary.config.relative_url_root || "/" do
-#   run Rails.application
-# end
+map Dromedary.config.relative_url_root || "/" do
+  run Rails.application
+end

--- a/config.ru
+++ b/config.ru
@@ -2,6 +2,7 @@
 
 require_relative "config/environment"
 
-map Dromedary.config.relative_url_root || "/" do
-  run Rails.application
-end
+run Rails.application
+# map Dromedary.config.relative_url_root || "/" do
+#   run Rails.application
+# end

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,7 @@ module Dromedary
 
     config.relative_url_root = Dromedary::Services[:relative_url_root]
     config.action_controller.relative_url_root = config.relative_url_root
+    # config.assets.prefix = Dromedary::Services[:relative_url_root]
     # config.relative_url_root                   = '/'
     # config.action_controller.relative_url_root = '/'
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,8 +33,7 @@ Rails.application.configure do
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.asset_host = ENV["CDN_HOST"] # Rails 7+ use the short version of this option
-  config.action_controller.asset_host = ENV["CDN_HOST"]
+  config.asset_host = ENV["CDN_HOST"]
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache

--- a/config/load_local_config.rb
+++ b/config/load_local_config.rb
@@ -49,7 +49,8 @@ module Dromedary
     end
 
     def collection_creation_date(coll:  Dromedary::Services[:solr_current_collection])
-      return @collection_creation_date if defined? @collection_creation_date
+      return @collection_creation_date if defined?(@collection_creation_date) && !@collection_creation_date.nil?
+
       real_collection_name = underlying_real_collection_name(coll: coll)
       m = /(\d{4})(\d{2})(\d{2})\d{4}\Z/.match(real_collection_name)
       @collection_creation_date = Time.parse(m[1..3].join("-"))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,9 @@ require "dromedary/services"
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-  scope Dromedary::Services[:relative_url_root] do
-    mount Blacklight::Engine => Dromedary.config.relative_url_root
+  # This scope should go away. The production prefix is managed at the Rack level.
+  scope "/" do
+    mount Blacklight::Engine => "/"
     # config/routes.rb, at any priority that suits you
     mount OkComputer::Engine, at: "/status"
 


### PR DESCRIPTION
There are many improvements to the Dockerfile here:

- The Dockerfile is now multi-stage so development and production are accounted for, but separate -- meaning development oriented tools like vim and ripgrep are added only to the locally built development image.
- The cache volumes are now used to hold APT packages, development, and production gems, and produce a clean bundle.
- The app service now runs in development mode, so the normal Rails development reloads work.
- The NodeJS install is moved to nodesource.
- The ruby image is slim by default, and is parameterized.
- The default (last) stage is development, so builds will give you the most likely useful thing by default.

Then, the most important substance here is the relative root URL handling:

- Development no longer uses or requires the relative root; localhost:3000, with working, reloadable assets.
- The rackup file manages the relative root, rather than in the routing, so assets are homed properly underneath.
- The `CDN_HOST` environment sets `config.asset_host`, allowing read-through CDN caching.
- The build action targets the production image, with the conventional prefix baked into its assets.