### PR TITLE
Add minimal Shrine + Uppy updater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 !**/.keep
 .byebug_history
 /solr_logs
+.app.env

--- a/Gemfile
+++ b/Gemfile
@@ -196,3 +196,8 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem "rsolr", ">= 1.0"
 gem "jquery-rails"
+
+gem "shrine", "~> 3.6"
+gem "aws-sdk-s3", "~> 1.160"
+gem "content_disposition", "~> 1.0"
+gem "uppy-s3_multipart", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,22 @@ GEM
     autoprefixer-rails (10.4.13.0)
       execjs (~> 2)
     awesome_print (1.9.2)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.971.0)
+    aws-sdk-core (3.203.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.9)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.89.0)
+      aws-sdk-core (~> 3, >= 3.203.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.160.0)
+      aws-sdk-core (~> 3, >= 3.203.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.9.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     bindex (0.8.1)
     blacklight (6.15.0)
       bootstrap-sass (~> 3.2)
@@ -86,6 +102,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.2.2)
     connection_pool (2.3.0)
+    content_disposition (1.0.0)
     crass (1.0.6)
     date (3.3.3)
     date_named_file (0.1.1)
@@ -102,6 +119,8 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dot-properties (0.1.4)
       bundler (>= 2.2.33)
+    down (5.4.2)
+      addressable (~> 2.8)
     erubi (1.12.0)
     ettin (1.3.0)
       deep_merge
@@ -147,6 +166,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jmespath (1.6.2)
     jquery-rails (4.5.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -274,6 +294,8 @@ GEM
     request_store (1.5.1)
       rack (>= 1.4)
     rexml (3.2.5)
+    roda (3.83.0)
+      rack
     rsolr (2.5.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
@@ -335,6 +357,9 @@ GEM
       websocket (~> 1.0)
     semantic_logger (4.12.0)
       concurrent-ruby (~> 1.0)
+    shrine (3.6.0)
+      content_disposition (~> 1.0)
+      down (~> 5.1)
     sidekiq (6.5.8)
       connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
@@ -398,6 +423,10 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
+    uppy-s3_multipart (1.2.1)
+      aws-sdk-s3 (~> 1.0)
+      content_disposition (~> 1.0)
+      roda (>= 2.27, < 4)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -419,10 +448,12 @@ DEPENDENCIES
   actionview (>= 5.2.4.3)
   activesupport (>= 5.2.4.3)
   awesome_print
+  aws-sdk-s3 (~> 1.160)
   blacklight (~> 6.15.0)
   bundler (~> 2.4.22)
   canister
   coffee-rails (~> 4.2)
+  content_disposition (~> 1.0)
   date_named_file
   debase
   ettin
@@ -457,6 +488,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver
   semantic_logger
+  shrine (~> 3.6)
   sidekiq
   simple_form (~> 5.0)
   simple_solr_client
@@ -468,6 +500,7 @@ DEPENDENCIES
   traject
   tzinfo-data
   uglifier (>= 1.3.0)
+  uppy-s3_multipart (~> 1.2)
   web-console (>= 3.3.0)
   websocket-extensions (>= 0.1.5)
   zinzout

--- a/app/controllers/updates_controller.rb
+++ b/app/controllers/updates_controller.rb
@@ -1,0 +1,6 @@
+class UpdatesController < ApplicationController
+  layout "uploader"
+
+  def index
+  end
+end

--- a/app/views/layouts/uploader.html.erb
+++ b/app/views/layouts/uploader.html.erb
@@ -1,0 +1,20 @@
+<%= extends :static do %>
+
+  <%= replace :head do %>
+    <link href="https://releases.transloadit.com/uppy/v4.3.0/uppy.min.css" rel="stylesheet">
+  <% end %>
+
+  <%= replace :main do %>
+
+    <div class="<%= container_classes %>">
+
+      <div class="row">
+        <%= yield %>
+      </div>
+
+    </div>
+
+
+  <% end %>
+
+<% end %>

--- a/app/views/updates/index.html.erb
+++ b/app/views/updates/index.html.erb
@@ -1,0 +1,38 @@
+<h1>Upload Compendium Data</h1>
+<div id="uppy"></div>
+
+<script type="module">
+  import { Uppy, Dashboard, AwsS3 } from "https://releases.transloadit.com/uppy/v4.3.0/uppy.min.mjs"
+  function onUploadComplete(result) {
+    console.log(
+      'Upload complete! We’ve uploaded these files:',
+      result.successful,
+    )
+  }
+  function onUploadSuccess(file, data) {
+    console.log(
+      'Upload success! We’ve uploaded this file:',
+      file.meta['name'],
+    )
+  }
+
+  const uppy = new Uppy({
+    restrictions: {
+      maxNumberOfFiles: 1,
+      allowedFileTypes: [".zip"],
+    }
+  })
+    .use(Dashboard, {
+      inline: true,
+      target: '#uppy'
+    })
+    .use(AwsS3, {
+      shouldUseMultipart(file) {
+        return file.size > 5 * 2 ** 20
+      },
+      endpoint: '<%= root_path %>'
+    })
+
+  uppy.on('complete', onUploadComplete)
+  uppy.on('upload-success', onUploadSuccess)
+</script>

--- a/compose.yml
+++ b/compose.yml
@@ -25,6 +25,9 @@ services:
       - SOLR_REPLICATION_FACTOR=1
       - DATA_ROOT=/mec/data
       - BUILD_ROOT=/mec/data/build
+    env_file:
+      - path: .app.env
+        required: false
     volumes:
       - .:/opt/app
       - data:/mec/data

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,14 @@ Rails.application.routes.draw do
 
     get "admin/reload_hyp_to_bibid" => "admin#reload_hyp_to_bibid", :as => :reload_hyp_to_bibid
 
+    # FIXME: Come up with something more robust to toggle all of the uploading
+    if Dromedary::Services[:aws_bucket].present?
+      get "/updates", to: "updates#index"
+      mount Shrine.presign_endpoint(:incoming), at: "/s3/params"
+      mount Shrine.uppy_s3_multipart(:incoming), at: "/s3/multipart"
+    end
+
+
     # 404s -- will only match if nothing else did
 
     match "quotations/*path" => "quotes#show404", :via => [:get, :post]

--- a/lib/dromedary/services.rb
+++ b/lib/dromedary/services.rb
@@ -3,6 +3,7 @@
 require "canister"
 require "date"
 require "uri"
+require "shrine/storage/s3"
 
 module Dromedary
   Services = Canister.new
@@ -132,6 +133,46 @@ module Dromedary
     ENV["SOLR_CONF_DIRECTORY"] || (Services[:root_directory] + "solr" + "dromedary" + "conf")
   end
 
+  # Incoming storage configuration; only for when uploader is enabled
+  Services.register(:aws_bucket) { ENV["AWS_BUCKET"] }
+  Services.register(:aws_region) { ENV["AWS_REGION"] }
+  Services.register(:aws_access_key_id) { ENV["AWS_ACCESS_KEY_ID"] }
+  Services.register(:aws_secret_access_key) { ENV["AWS_SECRET_ACCESS_KEY"] }
+  Services.register(:bucket_incoming_prefix) { ENV["BUCKET_INCOMING_PREFIX"] }
+
+  Services.register(:shrine_incoming_storage) do
+    {
+      prefix: Services[:bucket_incoming_prefix],
+      bucket: Services[:aws_bucket],
+      region: Services[:aws_region],
+      access_key_id: Services[:aws_access_key_id],
+      secret_access_key: Services[:aws_secret_access_key]
+    }
+  end
+
+  # FIXME: Come up with something more robust to toggle all of the uploading
+  if Services[:aws_bucket].present?
+    Shrine.storages = {
+      incoming: Shrine::Storage::S3.new(**Services[:shrine_incoming_storage])
+    }
+
+    Shrine.plugin :rack_file
+    Shrine.plugin :presign_endpoint, presign_options: -> (request) {
+      # Uppy will send the "filename" and "type" query parameters
+      filename = request.params["filename"]
+      type     = request.params["type"]
+
+      {
+        content_disposition:    ContentDisposition.inline(filename), # set download filename
+        content_type:           type,                                # set content type (required if using DigitalOcean Spaces)
+        content_length_range:   0..(10*1024*1024),                   # limit upload size to 10 MB
+      }
+    }
+
+    Shrine.plugin :uppy_s3_multipart
+  end
+
+  #######
 
   Services.register(:logger) { ::Rails.logger }
 


### PR DESCRIPTION
This fits together all of the little pieces to use multi-part uploads directly to S3, relieving the form rendering and temp file handling:

- Add Shrine
- Add AWS S3 SDK
- Add content disposition detection
- Add Uppy S3 multi part
- Add layout to load Uppy CSS from CDN in head section
- Load incoming bucket configuration from ENV
- Set up optional Compose env_file (.app.env; requires 2.24+)
- Condition the initialization on ENV vars being present
- Add routes for updates controller
- Add routes for presigned and multipart direct uploads
- Condition the routes on S3 ENV vars being present
- Add basic view to configure and show Uppy interface
- Load Uppy mjs from CDN inline in the view

It's not perfect, but it does work, and it does support pause/retry for partially completed uploads. The file lands in the incoming directory when the upload is fully complete.