### PR TITLE
[DRAFT! Check links!] Update DOE link targets and warning text

### DIFF
--- a/app/views/catalog/_related_entries.html.erb
+++ b/app/views/catalog/_related_entries.html.erb
@@ -23,9 +23,11 @@
 
       <% if ent.doelinks %>
         <div class="related-link-subhead">Dictionary of Old English</div>
+        <p class="oed-subscription-warning">(Please note that the DOE is a
+          subscription resource)</p>
         <ul>
           <% ent.doelinks.each do |elink| %>
-            <% oed_href = "http://tapor.library.utoronto.ca/doe/?E#{elink.target_id}" %>
+            <% oed_href = " https://dictionary.doe.utoronto.ca/doe/?E#{elink.target_id}" %>
             <li>
               <a class="external-link" href=<%= oed_href %>><%== elink.term %>
                 <img alt="Opens in a new window" src="/m/middle-english-dictionary/assets/external-link-blue-622a2080eed310c988c4462b76250bc28f3056e81fbd9b461b73ca2a1d9c6b99.svg"></a>


### PR DESCRIPTION
...as per [slack message from PFS](https://mlit.slack.com/archives/C83KQTUGK/p1724693732637709)

Links to DOE (both old format and new) don't seem to be working at all from my home machine; will check to see if it's a DNS issue or something)