### PR TITLE
Fix not-all-replicas-have-suggester by forcing hard commit before building suggester indexes

### DIFF
--- a/lib/med_installer/indexing_steps.rb
+++ b/lib/med_installer/indexing_steps.rb
@@ -174,6 +174,7 @@ module MedInstaller
         suggester_path = autocomplete_map[key]["solr_endpoint"]
         logger.info "   Recreate suggester for #{suggester_path}"
         resp = @build_collection.get "solr/#{@build_collection.name}/#{suggester_path}", { "suggest.build" => "true" }
+        @build_collection.commit(hard: true)
       end
     end
 

--- a/lib/med_installer/indexing_steps.rb
+++ b/lib/med_installer/indexing_steps.rb
@@ -163,6 +163,11 @@ module MedInstaller
       logger.info "  Start with a hard commit"
       @build_collection.commit(hard: true)
 
+      logger.info "Sleep 10 seconds to allow all replicas to get up to speed."
+      logger.info "   ...no, I don't know for sure that the 'sleep' is helping, but some replicas"
+      logger.info "      seem to not get the index built."
+      sleep 10
+
       autocomplete_filename = Services[:root_directory] + "config" + "autocomplete.yml"
       autocomplete_map = YAML.safe_load(ERB.new(File.read(autocomplete_filename)).result, aliases: true)[rails_env]
       autocomplete_map.keys.each do |key|

--- a/lib/med_installer/indexing_steps.rb
+++ b/lib/med_installer/indexing_steps.rb
@@ -67,9 +67,8 @@ module MedInstaller
       logger.info "Going to index targeting #{collection_url}"
       index_entries(solr_url: collection_url)
       index_bibs(solr_url: collection_url)
-      @build_collection.commit
       rebuild_suggesters
-      @build_collection.commit
+      @build_collection.commit(hard: true)
 
       logger.info "Cleaning up"
       @build_dir.rmtree
@@ -161,6 +160,9 @@ module MedInstaller
     # @param rails_env [String] "production" or "development"
     def rebuild_suggesters(rails_env: (ENV["RAILS_ENV"] || "production"))
       logger.info "Recreating suggest indexes"
+      logger.info "  Start with a hard commit"
+      @build_collection.commit(hard: true)
+
       autocomplete_filename = Services[:root_directory] + "config" + "autocomplete.yml"
       autocomplete_map = YAML.safe_load(ERB.new(File.read(autocomplete_filename)).result, aliases: true)[rails_env]
       autocomplete_map.keys.each do |key|


### PR DESCRIPTION
On indexing, some subset of the three solr replicas seem to not end up building the suggesters. This is a brute-force
attempt to fix that issue without truly understanding it.

Force a hard commit (finishing off the main indexing) and then sleep for ten seconds.