### PR TITLE
Build suggesters "manually" against each solr replica

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "middle_english_dictionary", git: "https://github.com/mlibrary/middle_englis
 gem "pg"
 gem "date_named_file"
 gem "zinzout"
-gem "solr_cloud-connection"
+gem "solr_cloud-connection", ">=0.6.0"
 
 gem "shrine", "~> 3.6"
 gem "aws-sdk-s3", "~> 1.160"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
     hashie (5.0.0)
     html_truncator (0.4.2)
       nokogiri (~> 1.5)
-    http-2 (1.0.0)
+    http-2 (1.0.1)
     http (5.1.1)
       addressable (~> 2.8)
       http-cookie (~> 1.0)
@@ -159,7 +159,7 @@ GEM
       domain_name (~> 0.5)
     http-form_data (2.3.0)
     httpclient (2.8.3)
-    httpx (1.3.0)
+    httpx (1.3.1)
       http-2 (>= 1.0.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -377,7 +377,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     slop (4.10.1)
-    solr_cloud-connection (0.5.0)
+    solr_cloud-connection (0.6.0)
       faraday (~> 2.0)
       httpx (~> 1.0)
       rubyzip (~> 2.0)
@@ -493,7 +493,7 @@ DEPENDENCIES
   simple_form (~> 5.0)
   simple_solr_client
   simplecov
-  solr_cloud-connection
+  solr_cloud-connection (>= 0.6.0)
   sprockets (~> 3.7.2)
   sqlite3 (~> 1.3.13)
   standard

--- a/compose.yml
+++ b/compose.yml
@@ -28,6 +28,9 @@ services:
       - ALLOW_ADMIN_ACCESS=1
       - RAILS_RELATIVE_URL_ROOT=/m/middle-english-dictionary
       - TZ=America/New_York
+      - "DIRECT_URLS_TO_SOLR_REPLICAS=http://solr:8983 http://solr:8983"
+      - MANUALLY_BUILD_SUGGESTERS=true
+      - PAUSE_TIME=10
     env_file:
       - path: .app.env
         required: false
@@ -53,7 +56,7 @@ services:
   solr:
     build: solr/.
     ports:
-      - "9090:8983"
+      - "9172:8983"
     environment:
       - ZK_HOST=zoo:2181
     depends_on:

--- a/lib/dromedary/services.rb
+++ b/lib/dromedary/services.rb
@@ -88,6 +88,19 @@ module Dromedary
 
   ################ Reindexing stuff ################
 
+  # For "manually" build suggesters using direct links to cluster replicas, because
+  # the cluster was losing nodes and the suggester indexes weren't getting build.
+
+  Services.register(:direct_urls_to_solr_replicas) do
+    ENV["DIRECT_URLS_TO_SOLR_REPLICAS"] or nil
+  end
+
+  Services.register(:manually_build_suggesters) do
+    val = ENV["MANUALLY_BUILD_SUGGESTERS"]
+    val =~ /\S/ and !(["false", 0, "0"].include? val.downcase)
+  end
+
+
   Services.register(:build_root) do
     br = Pathname.new(ENV["BUILD_ROOT"])
     br.mkpath


### PR DESCRIPTION
We were dealing with some instabilities in the k8s cluster in 2024.09 when we wanted to release this, resulting nodes loosing track of zookeeper and suggesters not getting built (calls would time out). Attempt to brute-force this by hitting the individual solr URLs directly, taking advantage of knowledge about how many replicas and what they're called that we'd really rather not have to know.

NOTE: Once it's determined we don't need this hack, tear the relevant code in MedInstaller:IndexingSteps#index (after the second call to @build_collection.commit), leaving only a single `rebuild_suggesters` and call it a day.

To run in once for each configured solr replica, we need the following:

  * ENV[DIRECT_URLS_TO_SOLR_REPLICAS]: A space-delimited set of urls of the form "http://solr-solrcloud-1:8083" or whatever. This is the same format as the generic (cluster-level) connection string found in ENV[SOLR_URL] (e.g., no trailing "solr")
  * A non-falsey value for ENV[MANUALLY_BUILD_SUGGESTERS] to enable it.