### PR TITLE
Add a middleware to force the HTTP Host

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,8 +254,6 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.2)
     rack (2.2.6.4)
-    rack-cors (2.0.2)
-      rack (>= 2.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (5.2.8.1)
@@ -481,7 +479,6 @@ DEPENDENCIES
   pry-rails
   puma (>= 4.3.5)
   rack (>= 2.1.4)
-  rack-cors
   rails (~> 5.0)
   rake (~> 13.0)
   rsolr (>= 1.0)

--- a/config/initializers/explicit_proxy_host.rb
+++ b/config/initializers/explicit_proxy_host.rb
@@ -1,0 +1,13 @@
+class ExplicitProxyHost
+  def initialize(app)
+    @app = app
+    @host = ENV['RAILS_URL_HOST']
+  end
+
+  def call(env)
+    env['HTTP_X_FORWARDED_HOST'] = @host unless @host.nil?
+    @app.call(env)
+  end
+end
+
+Rails.application.config.middleware.insert_before 0, ExplicitProxyHost


### PR DESCRIPTION
There appears to be a subtle interaction or bug between ingress-nginx and Rack in this case. Even with the upstream-vhost set and use-forwarded-headers unset, the Ingress host is being supplied as X-Forwarded-Host. Even with use-forwarded-headers set, the X-Forwarded-Host is getting the ingress host.

In Rack, the forwarded_authority takes precedence over the host_authority and server_authority... So, here we try to ensure that our value, supplied via process environment, is written into the forwarded host environment variable at the first position in the middleware stack.