### PR TITLE
Add semantic logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,8 +112,9 @@ gem "traject", require: false # only for indexing
 # Semantic logging?
 gem "awesome_print"
 gem "semantic_logger"
+gem "rails_semantic_logger"
 
-gem "lograge", ">=0.11.1"
+# gem "lograge", ">=0.11.1"
 
 # Contacts Email
 gem "mail_form", "~>1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,11 +191,6 @@ GEM
     llhttp-ffi (0.4.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
-    lograge (0.12.0)
-      actionpack (>= 4)
-      activesupport (>= 4)
-      railties (>= 4)
-      request_store (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -274,6 +269,10 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.5.0)
       loofah (~> 2.19, >= 2.19.1)
+    rails_semantic_logger (4.17.0)
+      rack
+      railties (>= 5.1)
+      semantic_logger (~> 4.16)
     railties (5.2.8.1)
       actionpack (= 5.2.8.1)
       activesupport (= 5.2.8.1)
@@ -291,8 +290,6 @@ GEM
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
-    request_store (1.5.1)
-      rack (>= 1.4)
     rexml (3.2.5)
     roda (3.83.0)
       rack
@@ -355,7 +352,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    semantic_logger (4.12.0)
+    semantic_logger (4.16.1)
       concurrent-ruby (~> 1.0)
     shrine (3.6.0)
       content_disposition (~> 1.0)
@@ -464,7 +461,6 @@ DEPENDENCIES
   jquery-rails
   kaminari (>= 1.2.1)
   listen
-  lograge (>= 0.11.1)
   loofah (>= 2.3.1)
   mail_form (~> 1.7)
   middle_english_dictionary!
@@ -480,6 +476,7 @@ DEPENDENCIES
   puma (>= 4.3.5)
   rack (>= 2.1.4)
   rails (~> 5.0)
+  rails_semantic_logger
   rake (~> 13.0)
   rsolr (>= 1.0)
   rspec-rails (~> 3.6)

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,8 +50,9 @@ module Dromedary
     config.log_tags = {
       ip: :remote_ip
     }
-
-    config.rails_semantic_logger.format = Dromedary::AbbreviatedJsonFormat.new
+    # Just use the standard :json logger and worry about filtering on the receiving end
+    # config.rails_semantic_logger.format = Dromedary::AbbreviatedJsonFormat.new
+    config.rails_semantic_logger.format = :json
     config.semantic_logger.add_appender(io: $stdout)
 
     config.active_record.yaml_column_permitted_classes = [ActiveSupport::HashWithIndifferentAccess]

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,6 +2,7 @@ require_relative "boot"
 require "rails/all"
 require "json"
 require_relative "../lib/dromedary/services"
+require_relative "../lib/dromedary/abbreviated_json_format"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -44,24 +45,14 @@ module Dromedary
     config.blacklight_url = Dromedary::Services[:solr_embedded_auth_url]
 
     config.log_level = :info
+    config.rails_semantic_logger.add_file_appender = false
+    config.semantic_logger.backtrace_level = :error
+    config.log_tags = {
+      ip: :remote_ip
+    }
 
-    config.lograge.enabled = false
-
-    # add time to lograge
-    config.lograge.custom_options = lambda do |event|
-      {time: event.time}
-    end
-
-    config.lograge.custom_payload do |controller|
-      {
-        host: controller.request.host,
-        ip: controller.request.ip,
-        query: controller.request.query_parameters
-      }
-    end
-
-    config.lograge.formatter = Lograge::Formatters::Json.new
-    config.active_job.queue_adapter = :sidekiq
+    config.rails_semantic_logger.format = Dromedary::AbbreviatedJsonFormat.new
+    config.semantic_logger.add_appender(io: $stdout)
 
     config.active_record.yaml_column_permitted_classes = [ActiveSupport::HashWithIndifferentAccess]
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,9 +57,9 @@ module Dromedary
 
     config.active_record.yaml_column_permitted_classes = [ActiveSupport::HashWithIndifferentAccess]
 
-    # config.log_tags = {
-    #   ip:         :remote_ip,
-    # }
+    config.log_tags = {
+      ip:         :remote_ip,
+    }
     # config.rails_semantic_logger.quiet_assets = true
     # config.rails_semantic_logger.format = :json
 

--- a/config/load_local_config.rb
+++ b/config/load_local_config.rb
@@ -31,9 +31,7 @@ module Dromedary
     end
 
     def hyp_to_bibid(collection: Dromedary::Services[:solr_current_collection])
-      logger.info "Trying to get hyp_to_bibid for collection #{collection}"
       current_real_collection_name = underlying_real_collection_name(coll: collection)
-      logger.info "Real collection name identified as #{current_real_collection_name}"
       if @recorded_real_collection_name != current_real_collection_name
         @hyp_to_bibid = MedInstaller::HypToBibId.get_from_solr(collection: collection)
         @recorded_real_collection_name = current_real_collection_name

--- a/lib/dromedary/abbreviated_json_format.rb
+++ b/lib/dromedary/abbreviated_json_format.rb
@@ -1,0 +1,33 @@
+require "rails_semantic_logger"
+
+module Dromedary
+  class AbbreviatedJsonFormat < SemanticLogger::Formatters::Json
+
+
+    def application
+      "MED"
+    end
+
+    def name; end
+
+    def host; end
+
+    def duration_ms; end
+
+    def pid; end
+
+    def level_index; end
+
+    def thread_name; end
+
+    def db_runtime; end
+
+    def process_info; end
+
+    def status_message; end
+
+    def params
+      super.reject { |k, v| %x(utf8 authenticity_token redirect db_runtime).include? k }
+    end
+  end
+end

--- a/lib/dromedary/abbreviated_json_format.rb
+++ b/lib/dromedary/abbreviated_json_format.rb
@@ -26,8 +26,5 @@ module Dromedary
 
     def status_message; end
 
-    def params
-      super.reject { |k, v| %x(utf8 authenticity_token redirect db_runtime).include? k }
-    end
   end
 end

--- a/lib/med_installer/logger.rb
+++ b/lib/med_installer/logger.rb
@@ -8,16 +8,15 @@ module MedInstaller
       end
     end
 
-    Formatter = MEDFormatter.new(time_format: "%Y-%m-%d:%H:%M:%S")
-    SemanticLogger.add_appender(io: $stderr, level: :info, formatter: Formatter)
+    SemanticLogger.add_appender(io: $stdout, formatter: :color)
+    # Formatter = MEDFormatter.new(time_format: "%Y-%m-%d:%H:%M:%S")
     LOGGER = SemanticLogger["Dromedary"]
 
     def logger
       if defined? Rails
         Rails.logger
-      else
-        LOGGER
       end
+      LOGGER
     end
   end
 end


### PR DESCRIPTION
Added rails_semantic_logger and configured rails to log :json results to STDOUT.

Tried to add remote_ip, which somehow isn't included in the standard json output.

Sample:

```json

{"host":"2084e8bbbfe4","application":"Semantic Logger","environment":"development","timestamp":"2024-09-26T01:49:13.474279Z","level":"info","level_index":2,"pid":1,"thread":"puma srv tp 001","duration_ms":486.46841700247023,"duration":"486.5ms","named_tags":{"ip":"172.18.0.1"},"name":"CatalogController","message":"Completed #show","payload":{"controller":"CatalogController","action":"show","params":{"authenticity_token":"h1j+vgylJrYMC0LcLrGQb078b+FCvYeHfWeXKFHeVTOznH6Ah9zeUhSeXDud4VvGjJKx/+H2SxZiGEtdTl2qKQ==","redirect":"/m/middle-english-dictionary/dictionary/MED124","counter":"4","search_id":"28","id":"MED124"},"format":"HTML","method":"POST","path":"/m/middle-english-dictionary/dictionary/MED124/track","status":200,"view_runtime":443.07,"db_runtime":2.44,"status_message":"OK"}}

```