### PR TITLE
A11y and design changes for MPP

### DIFF
--- a/app/assets/javascripts/blacklight/autocomplete.js.erb
+++ b/app/assets/javascripts/blacklight/autocomplete.js.erb
@@ -106,5 +106,9 @@ Blacklight.onLoad(function () {
     // Inititalize with the current value of the controller.
     $('[data-autocomplete-enabled]').each(BlacklightAutoComplete.setup_controller);
 
+    // Hide the Typeahead hint input from assistive technologies — it is a
+    // decorative overlay with no label and should not be focusable.
+    $('.tt-hint').attr('aria-hidden', 'true');
+
 });
 

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -35,6 +35,58 @@ body {
 
 /** Header **/
 
+.skip-links {
+  background: #00274c;
+  padding: 12px;
+  margin: 0 auto;
+}
+
+.skip-links .viewport-container {
+    width: 100%;
+    max-width: 1280px;
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: var(--viewport-margin);
+    padding-right: var(--viewport-margin);
+}
+
+.skip-links ul {
+  padding-left: 0;
+  margin-left: 0;
+  list-style: none;
+}
+
+.skip-links ul li {
+  margin: 16px 0;
+  text-align: center;
+  padding-left: 0;
+}
+
+.skip-links a {
+  color: #fff;
+  padding: 8px;
+}
+
+.skip-links a:visited {
+   color: #fff;
+}
+
+.skip-links:not(:focus-within) {
+    position: absolute;
+    left: -10000px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+
+#main-content:focus, #footer:focus {
+  outline: none;
+}
+#main-content:focus-visible, #footer:focus-visible {
+  box-shadow: 0 0 0 2px var(--color-maize-400), 0 0 0 3px var(--color-neutral-400);
+}
+
 .navbar-inverse {
   background-color: $u-m-blue;
   border: 0;
@@ -172,8 +224,7 @@ ul.header-nav-secondary li:hover {
   }
 
   .splash-text--caption {
-    font-size: .55em;
-    text-align: right;
+    font-size: .75em;
     padding: 2em 0;
   }
 
@@ -344,8 +395,12 @@ ul.header-nav-secondary li:hover {
 }
 
 .banner-text--caption {
-  float: right;
-  font-size: .55em;
+  font-size: .85em;
+  text-align: left;
+}
+
+.banner-text--caption a:hover {
+  color: #A7CDDB;
 }
 
 /** Header panel search bar **/
@@ -510,6 +565,10 @@ ul.header-nav-secondary li:hover {
   }
 }
 
+input#q::placeholder {
+  color: #555555;
+}
+
 .search-btn {
   background-color: #126DC1;
   border: none;
@@ -623,6 +682,11 @@ ul.header-nav-secondary li:hover {
     border: 3px solid $u-m-yellow;
   }
 }
+
+.search-bar--light-bg button#search:focus {
+    outline: 3px solid #ffcb05;
+    outline-offset: 0; 
+  }
 
 /** Home Page for Bib + Quotations **/
 
@@ -1076,6 +1140,14 @@ span.filterValue {
 
 /** Entry Page Dictionary/Bib **/
 
+.appliedFilter .remove:hover {
+  background-color: #A7CDDB;
+}
+
+.pagination > .disabled > span, .pagination > .disabled > span:hover, .pagination > .disabled > span:focus, .pagination > .disabled > a, .pagination > .disabled > a:hover, .pagination > .disabled > a:focus {
+ color: #686868;
+}
+
 .pagination-search-widgets {
   border: none;
 }
@@ -1271,7 +1343,7 @@ span.filterValue {
   }
 
   .quote-toggles a {
-    text-decoration: none;
+    text-decoration: underline;
   }
 
   a.hide-all-button,
@@ -1280,6 +1352,7 @@ span.filterValue {
     font-weight: 600;
     padding: .25em;
     font-size: 1.15em;
+    text-decoration: underline;
 
     &:focus {
       outline: none;
@@ -1340,13 +1413,12 @@ span.filterValue {
 table.table.table-striped,
 tbody > tr,
 tbody > tr > td,
-.table-responsive,
-{
+.table-responsive {
   border: 1px solid transparent !important;
 }
 
 table.table.table-striped,
-.table-responsive, {
+.table-responsive {
   border-radius: 5px;
   margin-bottom: 2em;
 }
@@ -1424,6 +1496,10 @@ body.blacklight-static,
   background-color: #f2f2f2;
   color: #333;
   line-height: 1.5;
+}
+
+body.blacklight-static > main {
+  margin-top: 30px;
 }
 
 #about_sidebar,
@@ -1614,7 +1690,7 @@ ul.about-list {
 
 .footer {
   width: 100%;
-  padding: 1rem 0;
+  padding: 1rem 0 0 0;
 }
 
 .footer-subfooter {

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -1502,6 +1502,10 @@ body.blacklight-static > main {
   margin-top: 30px;
 }
 
+caption {
+  color: #212B36;
+}
+
 #about_sidebar,
 #help_sidebar {
   margin-bottom: .75em;

--- a/app/views/application/_constraints_element.html.erb
+++ b/app/views/application/_constraints_element.html.erb
@@ -13,7 +13,7 @@
       <span class="filterName"><%= label %></span>
     <% end %>
     <% unless value.blank? %>
-      <%= content_tag :span, value, class: 'filterValue', title: value %>
+      <%= content_tag :span, value, class: 'filterValue' %>
     <% end %>
   </span>
   <% unless options[:remove].blank? %>

--- a/app/views/bibliography/index.html.erb
+++ b/app/views/bibliography/index.html.erb
@@ -15,6 +15,8 @@
     <span class="zero-results">No Results</span>
   <% elsif params[:f] and params[:f][:issue_identifier] %>
     <%= issue_title @document_list.first, complete: true %>
+  <% else %>
+    <span class="sr-only">Search Results</span>
   <% end %>
 <% end %>
 

--- a/app/views/bibliography/show.html.erb
+++ b/app/views/bibliography/show.html.erb
@@ -1,3 +1,7 @@
+<%= replace :h1_wrap do %>
+  <h1 class="sr-only"><%= Array(@document["title"]).first %></h1>
+<% end %>
+
 <div id="sidebar" class="<%= show_sidebar_classes %>">
    
 </div>

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -1,6 +1,6 @@
 <% if !params[:f].blank? %>
   <div id="appliedParams" class="clearfix constraints-container">
-    <h3 class="constraints-label">Current Filters</h3>
+    <h2 class="constraints-label">Current Filters</h2>
     <%= render_constraints(params) %>
     <div>
       <%=link_to t('blacklight.search.start_over'), start_over_path, :class => "catalog_startOverLink", :id=>"startOverLink" %>

--- a/app/views/catalog/_constraints_element.html.erb
+++ b/app/views/catalog/_constraints_element.html.erb
@@ -13,7 +13,7 @@
       <span class="filterName"><%= label %></span>
     <% end %>
     <% unless value.blank? %>
-      <%= content_tag :span, value, class: 'filterValue', title: value %>
+      <%= content_tag :span, value, class: 'filterValue'%>
     <% end %>
  
   <% unless options[:remove].blank? %>

--- a/app/views/catalog/_index_header_entry.html.erb
+++ b/app/views/catalog/_index_header_entry.html.erb
@@ -43,7 +43,7 @@
             <%# Trim it down to 300 chars, to the nearest space-break %>
             <% cdef = doc_presenter.def_html(sense).truncate(200) %>
             <div class="def-header">Sense / Definition</div>
-            <div class="definition"><%== cdef %><%= link_to("\u2026", document) %></div>
+            <div class="definition"><%== cdef %><%= link_to document do %><span aria-hidden="true">&#x2026;</span><span class="sr-only">Read full entry for <%= doc_presenter.headword_display(document) %></span><% end %></div>
           <% end %>
         </div>
       </div>

--- a/app/views/catalog/_related_entries.html.erb
+++ b/app/views/catalog/_related_entries.html.erb
@@ -3,7 +3,7 @@
 
 <% if ent.oedlinks or ent.doelinks %>
   <div class="panel panel-default">
-    <h3 class="panel-heading">Related Dictionary Entries</h3>
+    <h2 class="panel-heading">Related Dictionary Entries</h2>
     <div class="panel-body">
 
       <% if ent.oedlinks %>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -13,6 +13,8 @@
     <span class="zero-results">No Results</span>
   <% elsif params[:f] and params[:f][:issue_identifier] %>
     <%= issue_title @document_list.first, complete: true %>
+  <% else %>
+    <span class="sr-only">Search Results</span>
   <% end %>
 <% end %>
 

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,3 +1,7 @@
+<%= replace :h1_wrap do %>
+  <h1 class="sr-only"><%= Array(@document["headword"]).first %></h1>
+<% end %>
+
 <div id="sidebar" class="<%= show_sidebar_classes %>">
    <%= render partial: 'related_entries' %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
@@ -39,9 +39,11 @@
       x-forwarded host: <%= ENV["HTTP_X_FORWARDED_HOST"].inspect %>
     <% end %>
 
-    <%= area :main do %>
-      <p>Main content goes here.</p>
-    <% end %>
+    <main id="main-content" tabindex="-1">
+      <%= area :main do %>
+        <p>Main content goes here.</p>
+      <% end %>
+    </main>
 
     <%= render :partial => 'shared/footer' %>
 

--- a/app/views/layouts/splash.html.erb
+++ b/app/views/layouts/splash.html.erb
@@ -4,11 +4,7 @@
 
     <div>
 
-      <%= area :h1_wrap do %>
-          <div class="col-md-9 col-md-offset-3 col-sm-8 col-sm-offset-4 col-xs-12">
-            <h1><%= area :h1 %></h1>
-          </div>
-      <% end %>
+  
 
       <div>
         <%= yield %>

--- a/app/views/quotes/index.html.erb
+++ b/app/views/quotes/index.html.erb
@@ -15,6 +15,8 @@
     <span class="zero-results">No Results</span>
   <% elsif params[:f] and params[:f][:issue_identifier] %>
     <%= issue_title @document_list.first, complete: true %>
+  <% else %>
+    <span class="sr-only">Search Results</span>
   <% end %>
 <% end %>
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="footer footer--dark ">
+<footer class="footer footer--dark" id="footer" tabindex="-1">
   <div class="footer-container footer-text--light">
     <section>
       <ul>
@@ -27,7 +27,6 @@
 
     </section>
   </div>
-</footer>
 <div class="footer-subfooter footer--light">
   <div class="footer-container">
     <p class="font-xsmall">©<%= Time.now.year %>  Regents of the University of Michigan.
@@ -45,5 +44,5 @@
     </p>
   </div>
 </div>
-
+</footer>
 

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,21 +1,17 @@
+<div role="navigation" class="skip-links" aria-label="Skip links">
+  <div class="viewport-container">
+    <ul>
+      <li><a href="#main-content">Skip to main content</a></li>
+      <li><a href="#footer">Skip to footer content</a></li>
+    </ul>
+  </div>
+</div>
 <header class="site-header">
   <div id="header-navbar" class="navbar navbar-inverse navbar-static-top" role="navigation">
 
     <div class="container container--full site-header-container">
       <div class="site-title-container">
         <a href="<%=root_path %>" class="site-link site-title-flex"><img class="site-logo" src="https://apps.lib.umich.edu/falafel/v0/graphics/mlib_square__transparent.svg" alt="University of Michigan"><span class="site-title">Middle English Compendium</span></a>
-      </div>
-       <button type="button" class="navbar-toggle btn collapsed" data-toggle="collapse" data-target="#user-util-collapse">
-      <span class="sr-only">Toggle navigation</span>
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-      </button>
-
-      <%= area :skiplinks %>
-
-      <div class="collapse navbar-collapse" id="user-util-collapse">
-        <%= render :partial=>'/user_util_links' %>
       </div>
     </div>
 

--- a/public/404.html
+++ b/public/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>The page you were looking for doesn't exist (404)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/public/422.html
+++ b/public/422.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>The change you wanted was rejected (422)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/public/500.html
+++ b/public/500.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>We're sorry, but something went wrong (500)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">


### PR DESCRIPTION
## What's New

This PR fixes a series of accessibility issues found through the [MEC Baseline Evaluation Report](https://docs.google.com/document/d/11ViOHVvkaJlu1fyMyT1H3yD3zmZv-bC_kFtoP_4INoA/edit?tab=t.0#heading=h.8tfnur19cudx) and the most recent Siteimprove automated accessibility scanning. Remediation of these issues is required in April 2026.

## Accessibility Fixes

### Page Language

**`app/views/layouts/application.html.erb`**
**`public/404.html`**
**`public/422.html`**
**`public/500.html`**
- Added `lang="en"` to the `<html>` element so screen readers announce the
  correct language for page content.
  
### Empty List Element (Navbar)
**`app/views/shared/_header_navbar.html.erb`**
- Removed empty navbar collapse button and utility links partials
Note:  This is the "hamburger" button icon and child list in the header that shows up in medium and small mobile view and it is empty on my end and from a public view.

### Skip Links & ARIA Landmarks

**`app/views/shared/_header_navbar.html.erb`**
- Removed unused `<%= area :skiplinks %>` slot (replaced by hardcoded skip links)
- Added visible-on-focus skip link navigation targeting `#main-content` and `#footer`

**`app/views/layouts/application.html.erb`**
- Wrapped `area :main` content in `<main id="main-content" tabindex="-1">` to
  establish a main ARIA landmark and serve as the skip link target

**`app/assets/stylesheets/main.scss`**
- Added `.skip-links` styles: hidden off-screen until focused, then visible
- Added `#main-content:focus` and `#footer:focus` outline suppression with
  `focus-visible` focus ring styles for keyboard users

### Heading Hierarchy

**`app/views/catalog/_constraints.html.erb`**
**`app/views/catalog/_related_entries.html.erb`**
- Changed `<h3>` to `<h2>` to fix skipped heading levels. These sections appeared
  directly under the page `<h1>` with no intervening `<h2>`, violating heading
  order requirements.

### Typeahead Hint Input

**`app/assets/javascripts/blacklight/autocomplete.js.erb`**
- Added `aria-hidden="true"` to the `.tt-hint` input injected by Typeahead.js.
  This decorative ghost input had no label and was triggering an accessibility issue violation.

### Empty `<h1>` Elements

**`app/views/catalog/show.html.erb`**
- Added `replace :h1_wrap` block with sr-only `<h1>` populated from `document["headword"]`

**`app/views/bibliography/show.html.erb`**
- Added `replace :h1_wrap` block with sr-only `<h1>` populated from `document["title"]`

**`app/views/catalog/index.html.erb`**
**`app/views/bibliography/index.html.erb`**
**`app/views/quotes/index.html.erb`**
- Added `else` branch to `replace :h1` blocks to emit sr-only "Search Results" when
  results are present. Previously the `<h1>` rendered empty in the results.

### Filter Constraint Element

**`app/views/application/_constraints_element.html.erb`**
- Removed `title: value` attribute from the `.filterValue` span to prevent screen readers from announcing the filter value twice. Title should not be used on a non-interactive element

### Descriptive Link Text

**`app/views/catalog/_index_header_entry.html.erb`**
- Replaced bare `link_to("…", document)` with a block link containing `aria-hidden="true"` on the ellipsis character and an sr-only span reading  "Read full entry for [headword]"